### PR TITLE
feat(architect): switch model to Claude Sonnet 5 with High Effort

### DIFF
--- a/.github/workflows/architect.yml
+++ b/.github/workflows/architect.yml
@@ -53,13 +53,7 @@ jobs:
           esac
           echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
-          IS_BACKLOG_TRIAGE=false
-          case ",$TYPES," in *,origin:backlog-triage,*) IS_BACKLOG_TRIAGE=true;; esac
-          if [ "$IS_BACKLOG_TRIAGE" = "true" ]; then
-            echo "claude_model=claude-sonnet-5" >> "$GITHUB_OUTPUT"
-          else
-            echo "claude_model=claude-opus-5" >> "$GITHUB_OUTPUT"
-          fi
+          echo "claude_model=claude-sonnet-5" >> "$GITHUB_OUTPUT"
 
       - name: Fetch context (safe via gh/jq)
         if: steps.mode.outputs.mode != 'skip'
@@ -88,7 +82,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt_file: .github/workflows/prompts/architect-${{ steps.mode.outputs.mode }}.md
-          claude_args: '--model ${{ steps.mode.outputs.claude_model }} --permission-mode dontAsk --allowedTools "Read" "Grep" "Glob" "Write"'
+          claude_args: '--model ${{ steps.mode.outputs.claude_model }} --effort high --permission-mode dontAsk --allowedTools "Read" "Grep" "Glob" "Write"'
 
       - name: Handle output
         if: steps.mode.outputs.mode != 'skip' && steps.claude.outcome == 'success' && hashFiles('architect_output.json') != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Local CLI Pipeline wrapper scripts in `scripts/local-pipeline/`:
     - `run-backlog-triage.ps1`: Deterministic issue fetch/cluster/close with judgment-only `agy.exe` (Gemini 3.7 Flash Medium).
     - `run-pr-review.ps1`: Head-SHA tracked PR review with judgment-only `claude.exe` (Claude Sonnet 5, `--tools ""`, `--effort medium`).
-    - `run-architect.ps1`: Multi-mode story decomposition with read-only `claude.exe` (Claude Opus 5 / Sonnet 5, `--tools "Read,Grep,Glob"`, `--effort medium`).
+    - `run-architect.ps1`: Multi-mode story decomposition with read-only `claude.exe` (Claude Sonnet 5 with High Effort, `--tools "Read,Grep,Glob"`, `--effort high`).
     - `run-three-amigos-and-dev-test.ps1`: 5-step batch review, auto-rebase of approved conflicting PRs, agentic fix-up, in-flight concurrency gating, and new implementation.
     - `register-local-tasks.ps1`: Windows Task Scheduler registration for `DT-BacklogTriage`, `DT-PRReview`, `DT-Architect`, and `DT-ThreeAmigosDevTest`.
   - Scoped agent personas (`.antigravity/agents/developer.md`, `tester.md`) and workspace rules (`.antigravity/rules.md`).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pytest api_gateway/tests strategy_engine/tests
 ## 🤖 Agentic SDLC Pipeline
 
 Darwin Trader runs the full 5-node Agentic SDLC state graph:
-- **Architect (Claude Opus/Sonnet):** Decomposes PO User Stories (`user-story.yml`) into SMART subtasks (`subtask.yml`) via native GitHub Sub-issues.
+- **Architect (Claude Sonnet 5 - High Effort):** Decomposes PO User Stories (`user-story.yml`) into SMART subtasks (`subtask.yml`) via native GitHub Sub-issues with read-only repository tool exploration.
 - **Three Amigos (Gemini 3.7 Flash):** Batch readiness review across all subtasks for a story; evaluates QA testability and assigns E2E flow tags.
 - **Dev & Test (Gemini 3.7 Flash / Antigravity):** Implements subtasks, runs unit & delta E2E tests, auto-resolves approved conflicting PRs, and opens PRs with sticky test evidence.
 - **PR Review (Claude Sonnet):** Authoritative code review inspecting diffs, acceptance criteria, and `<!-- e2e-evidence -->` test comments.

--- a/scripts/local-pipeline/run-architect.ps1
+++ b/scripts/local-pipeline/run-architect.ps1
@@ -302,13 +302,13 @@ function Invoke-ArchitectJudge {
                        .Replace('{{ISSUE_COMMENTS_JSON}}', $commentsJson) `
                        .Replace('{{EXISTING_SUBTASKS_JSON}}', $subtasksJson)
 
-    Write-Log "Invoking claude.exe (model=$Model, mode=$Mode, effort=medium, tools=Read,Grep,Glob) for story #$issueNumber..."
+    Write-Log "Invoking claude.exe (model=$Model, mode=$Mode, effort=$Effort, tools=Read,Grep,Glob) for story #$issueNumber..."
 
     $result = $null
     try {
         $args = @(
             "--model", $Model,
-            "--effort", "medium",
+            "--effort", $Effort,
             "--output-format", "json",
             "--tools", "Read,Grep,Glob",
             "--permission-mode", "dontAsk",


### PR DESCRIPTION
﻿## Mission Plan: Switch Architect Node to Claude Sonnet 5 with High Effort

### Overview
Switches the model tier configuration of the Architect node in both the local CLI pipeline (`scripts/local-pipeline/run-architect.ps1`) and the GitHub Actions workflow (`.github/workflows/architect.yml`) to **Claude Sonnet 5** with **High Effort** (`--effort high`).

### Changes
- **Local Pipeline (`scripts/local-pipeline/run-architect.ps1`)**:
  - Configured default model: `claude-sonnet-5`
  - Added reasoning effort: `--effort high`
- **GitHub Actions Workflow (`.github/workflows/architect.yml`)**:
  - Unified model output to `claude-sonnet-5`
  - Added `--effort high` to `claude_args`
- **Documentation**:
  - Updated `README.md` and `CHANGELOG.md` to document the model update.
