### PR TITLE
Backend: Dynamic MT5 Account Connect & Status Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Dynamic MT5 Account Connect & Status Endpoints**:
+  - Added `POST /api/v1/account/connect` endpoint to configure MT5 credentials, toggle mock/live execution, and authenticate dynamically.
+  - Added `GET /api/v1/account/status` endpoint reporting connection state (`CONNECTED`, `DISCONNECTED`, `ERROR`), server mode, latency measurement in milliseconds, and error diagnostics.
+  - Extended `MT5Connector` with connection timestamping, latency calculation, disconnect capability, and comprehensive initialize/login error tracking.
+  - Added Pydantic models `AccountConnectRequest`, `AccountConnectResponse`, `ConnectionState`, and `ConnectionStatus` in `strategy_engine/models.py`.
 - **E2E Testing Framework with Maestro**:
   - Declarative E2E flows in `e2e/flows/` covering Dashboard metrics (`01_dashboard_flow.yaml`), Strategy parameters (`02_strategy_control_flow.yaml`), Backtest analytics (`03_backtest_analytics_flow.yaml`), and Navigation (`04_navigation_flow.yaml`).
   - Delta execution mapping (`e2e/flow-mapping.json`) mapping modified file globs across Android and Backend to targeted E2E tags.

--- a/api_gateway/routes_account.py
+++ b/api_gateway/routes_account.py
@@ -6,12 +6,60 @@ from typing import Dict, Any, List
 
 from strategy_engine.config import StrategyConfig
 from strategy_engine.mt5_connector import MT5Connector
-from strategy_engine.models import AccountInfo, Position
+from strategy_engine.models import (
+    AccountInfo,
+    Position,
+    AccountConnectRequest,
+    AccountConnectResponse,
+    ConnectionStatus,
+)
 
 router = APIRouter(prefix="/api/v1/account", tags=["Account & Telemetry"])
 
 # Use shared connector from routes_strategy
 from .routes_strategy import connector, global_config
+
+
+@router.post("/connect", response_model=AccountConnectResponse)
+def connect_account(request: AccountConnectRequest) -> AccountConnectResponse:
+    global_config.mt5_login = request.login
+    global_config.mt5_password = request.password
+    global_config.mt5_server = request.server
+    if request.path:
+        global_config.mt5_path = request.path
+    global_config.mock_mode = request.mock_mode
+
+    success, message = connector.initialize()
+    if not success:
+        return AccountConnectResponse(
+            status="ERROR",
+            message=message,
+            login=request.login,
+            server=request.server,
+            trade_mode="DEMO" if "demo" in request.server.lower() else "REAL",
+            balance=0.0,
+            currency="USD",
+            account_info=None,
+            error=message,
+        )
+
+    acc = connector.get_account_info()
+    return AccountConnectResponse(
+        status="CONNECTED",
+        message=message,
+        login=acc.login,
+        server=acc.server,
+        trade_mode=acc.trade_mode,
+        balance=acc.balance,
+        currency=acc.currency,
+        account_info=acc,
+        error=None,
+    )
+
+
+@router.get("/status", response_model=ConnectionStatus)
+def get_connection_status() -> ConnectionStatus:
+    return connector.get_connection_status()
 
 
 @router.get("/info", response_model=AccountInfo)

--- a/api_gateway/tests/test_api.py
+++ b/api_gateway/tests/test_api.py
@@ -55,3 +55,81 @@ def test_account_endpoints():
     resp_darwinex = client.get("/api/v1/account/darwinex-stats")
     assert resp_darwinex.status_code == 200
     assert "d_score" in resp_darwinex.json()
+
+
+def test_account_connect_and_status_success():
+    import time
+    start = time.perf_counter()
+    resp_connect = client.post(
+        "/api/v1/account/connect",
+        json={
+            "login": 987654,
+            "password": "secret_password",
+            "server": "Darwinex-Demo",
+            "mock_mode": True
+        }
+    )
+    elapsed = time.perf_counter() - start
+    assert elapsed < 2.0
+    assert resp_connect.status_code == 200
+    data = resp_connect.json()
+    assert data["status"] == "CONNECTED"
+    assert data["login"] == 987654
+    assert data["server"] == "Darwinex-Demo"
+    assert data["trade_mode"] == "DEMO"
+    assert data["balance"] == 100000.0
+    assert data["currency"] == "USD"
+    assert data["error"] is None
+
+    # Verify status reflects connection
+    resp_status = client.get("/api/v1/account/status")
+    assert resp_status.status_code == 200
+    status_data = resp_status.json()
+    assert status_data["status"] == "CONNECTED"
+    assert status_data["server"] == "Darwinex-Demo"
+    assert status_data["mock_mode"] is True
+    assert status_data["latency_ms"] >= 0.0
+    assert status_data["last_error"] is None
+    assert status_data["account_info"] is not None
+    assert status_data["account_info"]["login"] == 987654
+
+
+def test_account_connect_and_status_failure(monkeypatch):
+    import strategy_engine.mt5_connector as mc
+    monkeypatch.setattr(mc, "HAS_MT5", True)
+
+    class FakeMT5:
+        @staticmethod
+        def initialize(**kwargs):
+            return False
+
+        @staticmethod
+        def last_error():
+            return (-10005, "Invalid account login or password")
+
+    monkeypatch.setattr(mc, "mt5", FakeMT5)
+
+    resp_connect = client.post(
+        "/api/v1/account/connect",
+        json={
+            "login": 111111,
+            "password": "wrong_password",
+            "server": "Darwinex-Live",
+            "mock_mode": False
+        }
+    )
+    assert resp_connect.status_code == 200
+    data = resp_connect.json()
+    assert data["status"] == "ERROR"
+    assert "MT5 initialize failed" in data["message"]
+    assert data["error"] is not None
+
+    # Status endpoint reflects ERROR and error diagnostic
+    resp_status = client.get("/api/v1/account/status")
+    assert resp_status.status_code == 200
+    status_data = resp_status.json()
+    assert status_data["status"] == "ERROR"
+    assert status_data["server"] == "Darwinex-Live"
+    assert status_data["mock_mode"] is False
+    assert status_data["last_error"] == data["error"]
+    assert status_data["account_info"] is None

--- a/strategy_engine/models.py
+++ b/strategy_engine/models.py
@@ -86,3 +86,39 @@ class StrategyState(BaseModel):
     daily_drawdown_pct: float = 0.0
     total_trades_today: int = 0
     active_magic: int = 20260811
+
+
+class ConnectionState(str, Enum):
+    CONNECTED = "CONNECTED"
+    DISCONNECTED = "DISCONNECTED"
+    ERROR = "ERROR"
+
+
+class AccountConnectRequest(BaseModel):
+    login: int = 0
+    password: str = ""
+    server: str = "Darwinex-Demo"
+    path: Optional[str] = "C:\\Program Files\\Darwinex MetaTrader 5\\terminal64.exe"
+    mock_mode: bool = True
+
+
+class AccountConnectResponse(BaseModel):
+    status: str = "CONNECTED"
+    message: str = ""
+    login: int = 0
+    server: str = "Darwinex-Demo"
+    trade_mode: str = "DEMO"
+    balance: float = 100000.0
+    currency: str = "USD"
+    account_info: Optional[AccountInfo] = None
+    error: Optional[str] = None
+
+
+class ConnectionStatus(BaseModel):
+    status: str = "DISCONNECTED"
+    server: str = "Darwinex-Demo"
+    mock_mode: bool = True
+    latency_ms: float = 0.0
+    connected_at: Optional[datetime] = None
+    last_error: Optional[str] = None
+    account_info: Optional[AccountInfo] = None

--- a/strategy_engine/mt5_connector.py
+++ b/strategy_engine/mt5_connector.py
@@ -5,11 +5,13 @@ from typing import List, Optional, Tuple
 from datetime import datetime
 import os
 import platform
+import time
 
 from .config import StrategyConfig
-from .models import AccountInfo, Position, OrderType, TradeSignal, SignalType
+from .models import AccountInfo, Position, OrderType, TradeSignal, SignalType, ConnectionStatus
 
 # Try importing MetaTrader5 (available on Windows platform)
+mt5 = None
 HAS_MT5 = False
 if platform.system() == "Windows":
     try:
@@ -23,6 +25,9 @@ class MT5Connector:
     def __init__(self, config: StrategyConfig):
         self.config = config
         self.is_connected = False
+        self.connected_at: Optional[datetime] = None
+        self.last_error: Optional[str] = None
+        self.latency_ms: float = 0.0
         # Mock internal state for dev mode
         self._mock_positions: List[Position] = []
         self._mock_balance: float = 100000.0
@@ -32,22 +37,90 @@ class MT5Connector:
         """
         Initializes connection to MT5 terminal or starts mock mode.
         """
+        start_time = time.perf_counter()
         if self.config.mock_mode or not HAS_MT5:
             self.is_connected = True
+            self.connected_at = datetime.utcnow()
+            self.last_error = None
+            self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
             return True, "Initialized MT5 in MOCK / Simulation Mode"
 
         # Live MT5 execution branch
-        if not mt5.initialize(
-            path=self.config.mt5_path,
-            login=self.config.mt5_login,
-            password=self.config.mt5_password,
-            server=self.config.mt5_server
-        ):
+        try:
+            init_success = mt5.initialize(
+                path=self.config.mt5_path,
+                login=self.config.mt5_login,
+                password=self.config.mt5_password,
+                server=self.config.mt5_server
+            )
+        except Exception as e:
+            self.is_connected = False
+            self.connected_at = None
+            self.last_error = f"MT5 initialize exception: {e}"
+            self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
+            return False, self.last_error
+
+        self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
+        if not init_success:
             error_code = mt5.last_error()
-            return False, f"MT5 initialize failed: {error_code}"
+            self.is_connected = False
+            self.connected_at = None
+            self.last_error = f"MT5 initialize failed: {error_code}"
+            return False, self.last_error
+
+        if self.config.mt5_login:
+            try:
+                login_success = mt5.login(
+                    login=self.config.mt5_login,
+                    password=self.config.mt5_password,
+                    server=self.config.mt5_server
+                )
+            except Exception as e:
+                self.is_connected = False
+                self.connected_at = None
+                self.last_error = f"MT5 login exception: {e}"
+                return False, self.last_error
+
+            if not login_success:
+                error_code = mt5.last_error()
+                self.is_connected = False
+                self.connected_at = None
+                self.last_error = f"MT5 login failed: {error_code}"
+                return False, self.last_error
 
         self.is_connected = True
+        self.connected_at = datetime.utcnow()
+        self.last_error = None
         return True, "Connected to MetaTrader 5 live terminal"
+
+    def disconnect(self) -> Tuple[bool, str]:
+        """
+        Disconnects from MT5 terminal.
+        """
+        if HAS_MT5 and not self.config.mock_mode:
+            try:
+                mt5.shutdown()
+            except Exception as e:
+                self.last_error = str(e)
+        self.is_connected = False
+        self.connected_at = None
+        return True, "Disconnected from MetaTrader 5"
+
+    def get_connection_status(self) -> ConnectionStatus:
+        """
+        Returns connection state, latency, server mode, and diagnostic info.
+        """
+        status_str = "CONNECTED" if self.is_connected else ("ERROR" if self.last_error else "DISCONNECTED")
+        acc = self.get_account_info() if self.is_connected else None
+        return ConnectionStatus(
+            status=status_str,
+            server=self.config.mt5_server,
+            mock_mode=self.config.mock_mode,
+            latency_ms=self.latency_ms,
+            connected_at=self.connected_at,
+            last_error=self.last_error,
+            account_info=acc
+        )
 
     def get_account_info(self) -> AccountInfo:
         """
@@ -55,9 +128,10 @@ class MT5Connector:
         """
         if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
             floating_pnl = sum(p.pnl for p in self._mock_positions)
+            trade_mode = "DEMO" if "demo" in self.config.mt5_server.lower() else "REAL"
             return AccountInfo(
                 login=self.config.mt5_login or 1234567,
-                trade_mode="DEMO",
+                trade_mode=trade_mode,
                 server=self.config.mt5_server,
                 balance=self._mock_balance,
                 equity=self._mock_balance + floating_pnl,

--- a/strategy_engine/tests/test_strategy.py
+++ b/strategy_engine/tests/test_strategy.py
@@ -81,3 +81,58 @@ def test_mt5_connector_mock():
     count, kill_msg = connector.close_all_positions()
     assert count == 1
     assert len(connector.get_open_positions()) == 0
+
+
+def test_mt5_connector_status_and_disconnect():
+    config = StrategyConfig(mock_mode=True, mt5_server="Darwinex-Demo")
+    connector = MT5Connector(config)
+    assert connector.is_connected is False
+    status = connector.get_connection_status()
+    assert status.status == "DISCONNECTED"
+
+    ok, msg = connector.initialize()
+    assert ok is True
+    assert connector.is_connected is True
+    assert connector.connected_at is not None
+    assert connector.latency_ms >= 0.0
+
+    status = connector.get_connection_status()
+    assert status.status == "CONNECTED"
+    assert status.server == "Darwinex-Demo"
+    assert status.mock_mode is True
+    assert status.last_error is None
+    assert status.account_info is not None
+
+    ok_disc, msg_disc = connector.disconnect()
+    assert ok_disc is True
+    assert connector.is_connected is False
+    status = connector.get_connection_status()
+    assert status.status == "DISCONNECTED"
+
+
+def test_mt5_connector_live_init_failure(monkeypatch):
+    import strategy_engine.mt5_connector as mc
+    monkeypatch.setattr(mc, "HAS_MT5", True)
+
+    class FakeMT5:
+        @staticmethod
+        def initialize(**kwargs):
+            return False
+
+        @staticmethod
+        def last_error():
+            return (-10004, "Terminal not reachable")
+
+    monkeypatch.setattr(mc, "mt5", FakeMT5)
+
+    config = StrategyConfig(mock_mode=False, mt5_login=12345, mt5_password="bad", mt5_server="Darwinex-Live")
+    connector = MT5Connector(config)
+    ok, msg = connector.initialize()
+    assert ok is False
+    assert "MT5 initialize failed" in msg
+    assert connector.last_error is not None
+
+    status = connector.get_connection_status()
+    assert status.status == "ERROR"
+    assert status.last_error == msg
+    assert status.account_info is None


### PR DESCRIPTION
## Summary of Changes
Implements dynamic MT5 account connection and health monitoring endpoints for Darwin Trader:
- **\POST /api/v1/account/connect\**: Accepts credentials (\login\, \password\, \server\, \path\, \mock_mode\), initializes/authenticates the connection, and returns status \CONNECTED\ with account info (login ID, server, trade mode, balance, currency) or \ERROR\ with descriptive diagnostic details.
- **\GET /api/v1/account/status\**: Returns real-time connection state (\CONNECTED\, \DISCONNECTED\, \ERROR\), server mode (\Darwinex-Live\ / \Darwinex-Demo\), latency in milliseconds, timestamp, and diagnostic error message if disconnected.
- **\MT5Connector\**: Enhanced with latency tracking, timestamping, disconnect support, and initialize/login failure diagnostics.
- **Pydantic Models**: Added \AccountConnectRequest\, \AccountConnectResponse\, \ConnectionState\, and \ConnectionStatus\ in \strategy_engine/models.py\.
- **Test Coverage**: Added comprehensive unit tests covering successful mock connection, latency checks (<2.0s), live initialization failures, error status propagation, and disconnect in both \pi_gateway/tests/test_api.py\ and \strategy_engine/tests/test_strategy.py\.
- **Changelog**: Updated \CHANGELOG.md\ under \## [Unreleased]\.

## Test Results
- **Python Backend Unit Tests**: \12/12 passed\ (100% pass rate)
- **Android Unit Tests**: Gradle \	estSnapshotDebugUnitTest\ passed (BUILD SUCCESSFUL)

## Related Story & Issues
- Parent Story: #4
- Closes #5