### PR TITLE
Android: Account Settings / Connection Screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Android Account Settings & Connection Screen**:
+  - Added `AccountSettingsScreen.kt` Compose screen supporting MT5 login, password (with show/hide toggle), server selection, terminal path input, Mock/Live mode toggle, connection testing, and non-crashing troubleshooting guidance.
+  - Added `AccountConnectRequest`, `AccountConnectResponse`, and `AccountStatusResponse` data models in `Models.kt`.
+  - Added `connectAccount` and `getAccountStatus` suspend functions to `ApiService.kt`.
+  - Integrated `Account` navigation tab and state synchronization into `MainActivity.kt`.
+  - Added unit test suite `ModelsTest.kt` verifying serialization/deserialization across success and error response formats.
+  - Extended Maestro E2E test flows (`04_navigation_flow.yaml`, `05_account_connection_flow.yaml`) and delta flow mapping.
 - **Dynamic MT5 Account Connect & Status Endpoints**:
   - Added `POST /api/v1/account/connect` endpoint to configure MT5 credentials, toggle mock/live execution, and authenticate dynamically.
   - Added `GET /api/v1/account/status` endpoint reporting connection state (`CONNECTED`, `DISCONNECTED`, `ERROR`), server mode, latency measurement in milliseconds, and error diagnostics.

--- a/android/app/src/main/java/com/darwintrader/app/MainActivity.kt
+++ b/android/app/src/main/java/com/darwintrader/app/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.Dashboard
 import androidx.compose.material.icons.filled.Settings
@@ -15,6 +16,7 @@ import androidx.lifecycle.lifecycleScope
 import com.darwintrader.app.data.api.ApiService
 import com.darwintrader.app.data.model.AccountInfo
 import com.darwintrader.app.data.model.Position
+import com.darwintrader.app.ui.account.AccountSettingsScreen
 import com.darwintrader.app.ui.backtest.BacktestScreen
 import com.darwintrader.app.ui.dashboard.DashboardScreen
 import com.darwintrader.app.ui.strategy.StrategyControlScreen
@@ -77,6 +79,12 @@ class MainActivity : ComponentActivity() {
                                 icon = { Icon(Icons.Default.Analytics, contentDescription = "Backtest") },
                                 label = { Text("Backtest") }
                             )
+                            NavigationBarItem(
+                                selected = selectedTab == 3,
+                                onClick = { selectedTab = 3 },
+                                icon = { Icon(Icons.Default.AccountCircle, contentDescription = "Account") },
+                                label = { Text("Account") }
+                            )
                         }
                     }
                 ) { innerPadding ->
@@ -107,6 +115,13 @@ class MainActivity : ComponentActivity() {
                             )
                             1 -> StrategyControlScreen()
                             2 -> BacktestScreen()
+                            3 -> AccountSettingsScreen(
+                                apiService = apiService,
+                                onAccountConnected = {
+                                    accountInfo = it
+                                    fetchTelemetry()
+                                }
+                            )
                         }
                     }
                 }

--- a/android/app/src/main/java/com/darwintrader/app/data/api/ApiService.kt
+++ b/android/app/src/main/java/com/darwintrader/app/data/api/ApiService.kt
@@ -33,6 +33,12 @@ interface ApiService {
     @GET("api/v1/account/darwinex-stats")
     suspend fun getDarwinexStats(): Response<DarwinexStatsResponse>
 
+    @POST("api/v1/account/connect")
+    suspend fun connectAccount(@Body request: AccountConnectRequest): Response<AccountConnectResponse>
+
+    @GET("api/v1/account/status")
+    suspend fun getAccountStatus(): Response<AccountStatusResponse>
+
     companion object {
         private const val BASE_URL = "http://10.0.2.2:8000/" // Android Emulator localhost bridge
 

--- a/android/app/src/main/java/com/darwintrader/app/data/model/Models.kt
+++ b/android/app/src/main/java/com/darwintrader/app/data/model/Models.kt
@@ -52,3 +52,36 @@ data class GenericResponse(
     @SerializedName("message") val message: String,
     @SerializedName("status") val status: String? = null
 )
+
+data class AccountConnectRequest(
+    @SerializedName("login") val login: Long = 0,
+    @SerializedName("password") val password: String = "",
+    @SerializedName("server") val server: String = "Darwinex-Demo",
+    @SerializedName("path") val path: String? = "C:\\Program Files\\Darwinex MetaTrader 5\\terminal64.exe",
+    @SerializedName("mock_mode") val mockMode: Boolean = true
+)
+
+data class AccountConnectResponse(
+    @SerializedName("status") val status: String = "CONNECTED",
+    @SerializedName("message") val message: String = "",
+    @SerializedName("login") val login: Long = 0,
+    @SerializedName("server") val server: String = "Darwinex-Demo",
+    @SerializedName("trade_mode") val tradeMode: String = "DEMO",
+    @SerializedName("balance") val balance: Double = 100000.0,
+    @SerializedName("currency") val currency: String = "USD",
+    @SerializedName("account_info") val accountInfo: AccountInfo? = null,
+    @SerializedName("error") val error: String? = null
+)
+
+data class AccountStatusResponse(
+    @SerializedName("status") val status: String = "DISCONNECTED",
+    @SerializedName("server") val server: String = "Darwinex-Demo",
+    @SerializedName("mock_mode") val mockMode: Boolean = true,
+    @SerializedName("latency_ms") val latencyMs: Double = 0.0,
+    @SerializedName("connected_at") val connectedAt: String? = null,
+    @SerializedName("last_error") val lastError: String? = null,
+    @SerializedName("account_info") val accountInfo: AccountInfo? = null
+)
+
+typealias ConnectionStatusResponse = AccountStatusResponse
+

--- a/android/app/src/main/java/com/darwintrader/app/ui/account/AccountSettingsScreen.kt
+++ b/android/app/src/main/java/com/darwintrader/app/ui/account/AccountSettingsScreen.kt
@@ -1,0 +1,336 @@
+package com.darwintrader.app.ui.account
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.darwintrader.app.data.api.ApiService
+import com.darwintrader.app.data.model.AccountConnectRequest
+import com.darwintrader.app.data.model.AccountConnectResponse
+import com.darwintrader.app.data.model.AccountInfo
+import kotlinx.coroutines.launch
+
+@Composable
+fun AccountSettingsScreen(
+    apiService: ApiService = remember { ApiService.create() },
+    onAccountConnected: ((AccountInfo) -> Unit)? = null
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val scrollState = rememberScrollState()
+
+    var login by remember { mutableStateOf("105382") }
+    var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
+    var server by remember { mutableStateOf("Darwinex-Demo") }
+    var terminalPath by remember { mutableStateOf("C:\\Program Files\\Darwinex MetaTrader 5\\terminal64.exe") }
+    var mockMode by remember { mutableStateOf(true) }
+
+    var isLoading by remember { mutableStateOf(false) }
+    var connectResponse by remember { mutableStateOf<AccountConnectResponse?>(null) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    fun performConnectionTest() {
+        coroutineScope.launch {
+            isLoading = true
+            errorMessage = null
+            connectResponse = null
+            try {
+                val loginNum = login.trim().toLongOrNull() ?: 0L
+                val request = AccountConnectRequest(
+                    login = loginNum,
+                    password = password,
+                    server = server.trim(),
+                    path = terminalPath.trim().ifBlank { null },
+                    mockMode = mockMode
+                )
+                val response = apiService.connectAccount(request)
+                if (response.isSuccessful && response.body() != null) {
+                    val body = response.body()!!
+                    connectResponse = body
+                    if (body.status == "CONNECTED") {
+                        body.accountInfo?.let { onAccountConnected?.invoke(it) }
+                    } else {
+                        errorMessage = body.error ?: body.message.ifBlank { "Connection failed on $server" }
+                    }
+                } else {
+                    errorMessage = "Server error (HTTP ${response.code()}): ${response.message().ifBlank { "Failed to connect" }}"
+                }
+            } catch (e: Exception) {
+                errorMessage = e.localizedMessage ?: "Network error: Unable to reach Darwin Trader gateway"
+            } finally {
+                isLoading = false
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scrollState)
+            .padding(16.dp)
+    ) {
+        Text(
+            text = "Account & MT5 Connection",
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+
+        Text(
+            text = "Configure your Darwinex Zero / DarwinX MT5 credentials",
+            fontSize = 14.sp,
+            color = Color.Gray
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Configuration Card Form
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                // Mock Mode Toggle
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = if (mockMode) "Mock Simulation Mode" else "Live MT5 Terminal",
+                            fontWeight = FontWeight.SemiBold,
+                            fontSize = 16.sp
+                        )
+                        Text(
+                            text = if (mockMode) "Simulates MT5 IPC responses locally" else "Connects to running MT5 terminal via IPC",
+                            fontSize = 12.sp,
+                            color = Color.Gray
+                        )
+                    }
+                    Switch(
+                        checked = mockMode,
+                        onCheckedChange = { mockMode = it }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider(color = Color.DarkGray)
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Login Field
+                OutlinedTextField(
+                    value = login,
+                    onValueChange = { login = it },
+                    label = { Text("MT5 Login / Account ID") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Password Field
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("MT5 Password") },
+                    visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible) Icons.Default.Visibility else Icons.Default.VisibilityOff,
+                                contentDescription = if (passwordVisible) "Hide password" else "Show password"
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Server Field
+                OutlinedTextField(
+                    value = server,
+                    onValueChange = { server = it },
+                    label = { Text("MT5 Server (e.g. Darwinex-Live, Darwinex-Demo)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Terminal Path Field
+                OutlinedTextField(
+                    value = terminalPath,
+                    onValueChange = { terminalPath = it },
+                    label = { Text("MT5 Terminal Path") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Action Button
+                Button(
+                    onClick = { performConnectionTest() },
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !isLoading,
+                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                ) {
+                    if (isLoading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            color = Color.Black,
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("CONNECTING...", fontWeight = FontWeight.Bold, color = Color.Black)
+                    } else {
+                        Text("TEST CONNECTION", fontWeight = FontWeight.Bold, color = Color.Black)
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Connection Success State
+        if (connectResponse != null && connectResponse?.status == "CONNECTED") {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.CheckCircle,
+                            contentDescription = "Connected",
+                            tint = Color(0xFF00E676)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "CONNECTED",
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF00E676),
+                            fontSize = 18.sp
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = connectResponse?.message ?: "Account authenticated successfully.",
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+                    HorizontalDivider(color = Color.DarkGray)
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column {
+                            Text("Account ID", fontSize = 12.sp, color = Color.Gray)
+                            Text("${connectResponse?.login}", fontWeight = FontWeight.SemiBold)
+                        }
+                        Column {
+                            Text("Server", fontSize = 12.sp, color = Color.Gray)
+                            Text("${connectResponse?.server}", fontWeight = FontWeight.SemiBold)
+                        }
+                        Column {
+                            Text("Balance", fontSize = 12.sp, color = Color.Gray)
+                            Text(
+                                "$${String.format("%.2f", connectResponse?.balance ?: 0.0)}",
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Connection Error / Troubleshooting State
+        if (errorMessage != null) {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = Icons.Default.Error,
+                            contentDescription = "Connection Error",
+                            tint = MaterialTheme.colorScheme.tertiary
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "CONNECTION FAILED",
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.tertiary,
+                            fontSize = 16.sp
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = errorMessage ?: "Unknown error occurred during connection",
+                        fontSize = 14.sp,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // Helpful troubleshooting advice
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Color(0xFF2C1A1D), shape = RoundedCornerShape(8.dp))
+                            .padding(12.dp)
+                    ) {
+                        Column {
+                            Text(
+                                text = "Troubleshooting tips:",
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.tertiary
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = "• Verify MT5 terminal is running if in Live mode\n• Check server name (e.g. Darwinex-Live vs Darwinex-Demo)\n• Confirm account login ID and password are correct\n• Ensure terminal path points to terminal64.exe",
+                                fontSize = 12.sp,
+                                color = Color.LightGray
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/test/java/com/darwintrader/app/ModelsTest.kt
+++ b/android/app/src/test/java/com/darwintrader/app/ModelsTest.kt
@@ -1,0 +1,114 @@
+package com.darwintrader.app
+
+import com.darwintrader.app.data.model.*
+import com.google.gson.Gson
+import org.junit.Assert.*
+import org.junit.Test
+
+class ModelsTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun testAccountConnectRequestSerialization() {
+        val request = AccountConnectRequest(
+            login = 123456L,
+            password = "securePassword",
+            server = "Darwinex-Live",
+            path = "C:\\MT5\\terminal64.exe",
+            mockMode = false
+        )
+
+        val json = gson.toJson(request)
+        assertTrue(json.contains("\"login\":123456"))
+        assertTrue(json.contains("\"password\":\"securePassword\""))
+        assertTrue(json.contains("\"server\":\"Darwinex-Live\""))
+        assertTrue(json.contains("\"path\":\"C:\\\\MT5\\\\terminal64.exe\""))
+        assertTrue(json.contains("\"mock_mode\":false"))
+    }
+
+    @Test
+    fun testAccountConnectResponseDeserialization_success() {
+        val json = """
+            {
+                "status": "CONNECTED",
+                "message": "Connected to Darwinex-Demo in mock mode",
+                "login": 105382,
+                "server": "Darwinex-Demo",
+                "trade_mode": "DEMO",
+                "balance": 100000.0,
+                "currency": "USD",
+                "account_info": {
+                    "login": 105382,
+                    "trade_mode": "DEMO",
+                    "server": "Darwinex-Demo",
+                    "balance": 100000.0,
+                    "equity": 100000.0,
+                    "d_score": 75.4
+                },
+                "error": null
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, AccountConnectResponse::class.java)
+        assertEquals("CONNECTED", response.status)
+        assertEquals(105382L, response.login)
+        assertEquals("Darwinex-Demo", response.server)
+        assertEquals("DEMO", response.tradeMode)
+        assertEquals(100000.0, response.balance, 0.001)
+        assertNull(response.error)
+        assertNotNull(response.accountInfo)
+        assertEquals(75.4, response.accountInfo?.dScore ?: 0.0, 0.001)
+    }
+
+    @Test
+    fun testAccountConnectResponseDeserialization_error() {
+        val json = """
+            {
+                "status": "ERROR",
+                "message": "Terminal not running",
+                "login": 999999,
+                "server": "Darwinex-Live",
+                "trade_mode": "REAL",
+                "balance": 0.0,
+                "currency": "USD",
+                "account_info": null,
+                "error": "Terminal not running: IPC pipe closed"
+            }
+        """.trimIndent()
+
+        val response = gson.fromJson(json, AccountConnectResponse::class.java)
+        assertEquals("ERROR", response.status)
+        assertEquals("Terminal not running: IPC pipe closed", response.error)
+        assertEquals(0.0, response.balance, 0.001)
+        assertNull(response.accountInfo)
+    }
+
+    @Test
+    fun testAccountStatusResponseDeserialization() {
+        val json = """
+            {
+                "status": "CONNECTED",
+                "server": "Darwinex-Live",
+                "mock_mode": false,
+                "latency_ms": 1.45,
+                "connected_at": "2026-08-26T21:45:00",
+                "last_error": null,
+                "account_info": {
+                    "login": 55555,
+                    "balance": 50000.0
+                }
+            }
+        """.trimIndent()
+
+        val status = gson.fromJson(json, AccountStatusResponse::class.java)
+        assertEquals("CONNECTED", status.status)
+        assertEquals("Darwinex-Live", status.server)
+        assertFalse(status.mockMode)
+        assertEquals(1.45, status.latencyMs, 0.001)
+        assertEquals("2026-08-26T21:45:00", status.connectedAt)
+        assertNull(status.lastError)
+        assertNotNull(status.accountInfo)
+        assertEquals(55555L, status.accountInfo?.login)
+    }
+}

--- a/e2e/flow-mapping.json
+++ b/e2e/flow-mapping.json
@@ -15,6 +15,10 @@
       "tags": ["backtest"]
     },
     {
+      "pattern": "android/app/src/main/java/**/ui/account/**",
+      "tags": ["account", "core"]
+    },
+    {
       "pattern": "android/app/src/main/java/**/ui/theme/**",
       "tags": ["theme", "core"]
     },

--- a/e2e/flows/04_navigation_flow.yaml
+++ b/e2e/flows/04_navigation_flow.yaml
@@ -9,6 +9,9 @@ tags:
 - assertVisible: "Strategy Parameters"
 - tapOn: "Backtest"
 - assertVisible: "Backtest Analytics"
+- tapOn: "Account"
+- assertVisible: "Account & MT5 Connection"
 - tapOn: "Dashboard"
 - assertVisible: "Account Equity"
 - takeScreenshot: screenshots/04_navigation_complete
+

--- a/e2e/flows/05_account_connection_flow.yaml
+++ b/e2e/flows/05_account_connection_flow.yaml
@@ -1,0 +1,13 @@
+appId: com.darwintrader.app.snapshot
+tags:
+  - account
+  - core
+---
+- launchApp:
+    clearState: false
+- tapOn: "Account"
+- assertVisible: "Account & MT5 Connection"
+- assertVisible: "Mock Simulation Mode"
+- tapOn: "TEST CONNECTION"
+- assertVisible: "CONNECTED"
+- takeScreenshot: screenshots/05_account_connection_complete


### PR DESCRIPTION
## Mission Plan: Android Account Settings / Connection Screen

### Summary of Changes
- **Account Settings Screen (`AccountSettingsScreen.kt`)**:
  - Implemented Compose UI form with fields for MT5 login, password (with show/hide visibility toggle), server (e.g. `Darwinex-Live`, `Darwinex-Demo`), and terminal path.
  - Added toggle for Mock Simulation Mode vs Live MT5 Terminal IPC.
  - Added `TEST CONNECTION` action triggering asynchronous authentication against `POST /api/v1/account/connect`.
  - Added reactive status UI displaying `CONNECTED` badge with account balance and telemetry on success, or non-crashing `CONNECTION FAILED` card with actionable troubleshooting advice on failure or network errors.
- **Data Models (`Models.kt`)**:
  - Added `AccountConnectRequest`, `AccountConnectResponse`, and `AccountStatusResponse` data classes with Gson annotations matching the FastAPI gateway models.
- **API Service (`ApiService.kt`)**:
  - Added `connectAccount(@Body request: AccountConnectRequest)` and `getAccountStatus()` suspend endpoints.
- **Main Navigation (`MainActivity.kt`)**:
  - Added bottom navigation tab for `Account` (`Icons.Default.AccountCircle`) and wired connection success telemetry updates into global app state.
- **Unit & E2E Testing**:
  - Added `ModelsTest.kt` covering serialization/deserialization across success and error payloads.
  - Extended Maestro navigation flow and added `05_account_connection_flow.yaml` and updated `flow-mapping.json`.
- **Changelog**:
  - Updated `CHANGELOG.md` under `[Unreleased]` following Keep a Changelog.

### Test Results
- **Android Unit Tests**: `testSnapshotDebugUnitTest` — PASSED (100%)
- **Backend Test Suite**: `pytest api_gateway/tests strategy_engine/tests` — 12/12 PASSED (100%)
- **Build Verification**: `assembleSnapshotDebug` — SUCCESSFUL

Parent Story: #4
Closes #6
