### PR TITLE
Android: Dashboard Live Connection Telemetry Badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Android Dashboard Live Connection Telemetry Badge**:
+  - Updated `DashboardScreen.kt` with live connection status badge (`Connected (Live)`, `Connected (Demo)`, `Simulation`, `Disconnected`) and Account ID display sourced from connection telemetry alongside strategy status.
+  - Extended `MainActivity.kt` telemetry polling loop (`LaunchedEffect`) and tab-switch triggers to fetch `GET /api/v1/account/status` via `ApiService.getAccountStatus()` and propagate live status to `DashboardScreen`.
+  - Added `getConnectionBadgeText()` helper extension on `AccountStatusResponse` in `Models.kt` mapping server mode, mock flag, and error status safely.
+  - Added unit test suite in `ModelsTest.kt` testing connection badge label derivation across Live, Demo, Simulation, Disconnected, and Error states.
+  - Updated `android/app/build.gradle.kts` snapshot flavor applicationId and added automatic local backend gateway launching in `scripts/run-e2e-tests.ps1` for end-to-end Maestro verification.
 - **Android Account Settings & Connection Screen**:
   - Added `AccountSettingsScreen.kt` Compose screen supporting MT5 login, password (with show/hide toggle), server selection, terminal path input, Mock/Live mode toggle, connection testing, and non-crashing troubleshooting guidance.
   - Added `AccountConnectRequest`, `AccountConnectResponse`, and `AccountStatusResponse` data models in `Models.kt`.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -36,7 +36,6 @@ android {
         create("snapshot") {
             dimension = "version"
             applicationId = "com.darwintrader.app.snapshot"
-            applicationIdSuffix = ".snapshot"
             resValue("string", "app_name", "Darwin Trader Snapshot")
         }
     }

--- a/android/app/src/main/java/com/darwintrader/app/MainActivity.kt
+++ b/android/app/src/main/java/com/darwintrader/app/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import com.darwintrader.app.data.api.ApiService
 import com.darwintrader.app.data.model.AccountInfo
+import com.darwintrader.app.data.model.AccountStatusResponse
 import com.darwintrader.app.data.model.Position
 import com.darwintrader.app.ui.account.AccountSettingsScreen
 import com.darwintrader.app.ui.backtest.BacktestScreen
@@ -34,6 +35,7 @@ class MainActivity : ComponentActivity() {
                 var accountInfo by remember { mutableStateOf(AccountInfo()) }
                 var positions by remember { mutableStateOf<List<Position>>(emptyList()) }
                 var strategyStatus by remember { mutableStateOf("IDLE") }
+                var accountStatus by remember { mutableStateOf<AccountStatusResponse?>(null) }
 
                 fun fetchTelemetry() {
                     lifecycleScope.launch {
@@ -46,13 +48,31 @@ class MainActivity : ComponentActivity() {
 
                             val statusRes = apiService.getStrategyStatus()
                             if (statusRes.isSuccessful) statusRes.body()?.let { strategyStatus = it.status }
+
+                            val connRes = apiService.getAccountStatus()
+                            if (connRes.isSuccessful) {
+                                connRes.body()?.let {
+                                    accountStatus = it
+                                    it.accountInfo?.let { acc -> accountInfo = acc }
+                                }
+                            } else {
+                                accountStatus = AccountStatusResponse(status = "DISCONNECTED")
+                            }
                         } catch (e: Exception) {
                             // Fallback to default mock data if offline
+                            accountStatus = AccountStatusResponse(status = "DISCONNECTED")
                         }
                     }
                 }
 
                 LaunchedEffect(Unit) {
+                    while (true) {
+                        fetchTelemetry()
+                        kotlinx.coroutines.delay(5000)
+                    }
+                }
+
+                LaunchedEffect(selectedTab) {
                     fetchTelemetry()
                 }
 
@@ -94,6 +114,7 @@ class MainActivity : ComponentActivity() {
                                 accountInfo = accountInfo,
                                 positions = positions,
                                 strategyStatus = strategyStatus,
+                                accountStatus = accountStatus,
                                 onStartStrategy = {
                                     lifecycleScope.launch {
                                         apiService.startStrategy()

--- a/android/app/src/main/java/com/darwintrader/app/data/model/Models.kt
+++ b/android/app/src/main/java/com/darwintrader/app/data/model/Models.kt
@@ -85,3 +85,18 @@ data class AccountStatusResponse(
 
 typealias ConnectionStatusResponse = AccountStatusResponse
 
+fun AccountStatusResponse?.getConnectionBadgeText(): String {
+    if (this == null) return "Disconnected"
+    return when (this.status.uppercase()) {
+        "CONNECTED" -> {
+            if (this.mockMode) {
+                "Simulation"
+            } else if (this.server.contains("Live", ignoreCase = true)) {
+                "Connected (Live)"
+            } else {
+                "Connected (Demo)"
+            }
+        }
+        else -> "Disconnected"
+    }
+}

--- a/android/app/src/main/java/com/darwintrader/app/ui/dashboard/DashboardScreen.kt
+++ b/android/app/src/main/java/com/darwintrader/app/ui/dashboard/DashboardScreen.kt
@@ -14,7 +14,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.darwintrader.app.data.model.AccountInfo
+import com.darwintrader.app.data.model.AccountStatusResponse
 import com.darwintrader.app.data.model.Position
+import com.darwintrader.app.data.model.getConnectionBadgeText
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -22,6 +24,7 @@ fun DashboardScreen(
     accountInfo: AccountInfo,
     positions: List<Position>,
     strategyStatus: String,
+    accountStatus: AccountStatusResponse? = null,
     onStartStrategy: () -> Unit,
     onPauseStrategy: () -> Unit,
     onKillSwitch: () -> Unit
@@ -51,12 +54,35 @@ fun DashboardScreen(
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
             ) {
                 Column(modifier = Modifier.padding(16.dp)) {
+                    val connBadgeText = accountStatus.getConnectionBadgeText()
+                    val connBadgeBg = when (connBadgeText) {
+                        "Connected (Live)" -> Color(0xFF00E676)
+                        "Connected (Demo)" -> Color(0xFF29B6F6)
+                        "Simulation" -> Color(0xFFFFB300)
+                        else -> Color(0xFF757575)
+                    }
+                    val connBadgeTextColor = when (connBadgeText) {
+                        "Disconnected" -> Color.White
+                        else -> Color.Black
+                    }
+
+                    val effectiveLogin = accountStatus?.accountInfo?.login?.takeIf { it != 0L }
+                        ?: accountInfo.login.takeIf { it != 0L }
+
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Column {
+                            if (effectiveLogin != null) {
+                                Text(
+                                    "Account #$effectiveLogin",
+                                    fontSize = 12.sp,
+                                    color = Color.LightGray,
+                                    fontWeight = FontWeight.Medium
+                                )
+                            }
                             Text("Account Equity", fontSize = 12.sp, color = Color.Gray)
                             Text(
                                 "$${String.format("%.2f", accountInfo.equity)}",
@@ -65,20 +91,57 @@ fun DashboardScreen(
                                 color = MaterialTheme.colorScheme.primary
                             )
                         }
-                        Box(
-                            modifier = Modifier
-                                .background(
-                                    if (strategyStatus == "RUNNING") Color(0xFF00E676) else Color(0xFFFFB300),
-                                    shape = RoundedCornerShape(8.dp)
-                                )
-                                .padding(horizontal = 12.dp, vertical = 6.dp)
+
+                        Column(
+                            horizontalAlignment = Alignment.End,
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
                         ) {
-                            Text(
-                                strategyStatus,
-                                color = Color.Black,
-                                fontWeight = FontWeight.Bold,
-                                fontSize = 12.sp
-                            )
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                // Connection Status Badge
+                                Box(
+                                    modifier = Modifier
+                                        .background(
+                                            connBadgeBg,
+                                            shape = RoundedCornerShape(8.dp)
+                                        )
+                                        .padding(horizontal = 10.dp, vertical = 6.dp)
+                                ) {
+                                    Text(
+                                        connBadgeText,
+                                        color = connBadgeTextColor,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 12.sp
+                                    )
+                                }
+
+                                // Strategy Status Badge
+                                Box(
+                                    modifier = Modifier
+                                        .background(
+                                            if (strategyStatus == "RUNNING") Color(0xFF00E676) else Color(0xFFFFB300),
+                                            shape = RoundedCornerShape(8.dp)
+                                        )
+                                        .padding(horizontal = 10.dp, vertical = 6.dp)
+                                ) {
+                                    Text(
+                                        strategyStatus,
+                                        color = Color.Black,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 12.sp
+                                    )
+                                }
+                            }
+                            if (effectiveLogin != null) {
+                                Text(
+                                    "ID: $effectiveLogin",
+                                    fontSize = 11.sp,
+                                    color = Color.Gray,
+                                    fontWeight = FontWeight.Normal
+                                )
+                            }
                         }
                     }
 

--- a/android/app/src/test/java/com/darwintrader/app/ModelsTest.kt
+++ b/android/app/src/test/java/com/darwintrader/app/ModelsTest.kt
@@ -111,4 +111,62 @@ class ModelsTest {
         assertNotNull(status.accountInfo)
         assertEquals(55555L, status.accountInfo?.login)
     }
+
+    @Test
+    fun testConnectionBadgeText_liveConnected() {
+        val status = AccountStatusResponse(
+            status = "CONNECTED",
+            server = "Darwinex-Live",
+            mockMode = false
+        )
+        assertEquals("Connected (Live)", status.getConnectionBadgeText())
+    }
+
+    @Test
+    fun testConnectionBadgeText_demoConnected() {
+        val status = AccountStatusResponse(
+            status = "CONNECTED",
+            server = "Darwinex-Demo",
+            mockMode = false
+        )
+        assertEquals("Connected (Demo)", status.getConnectionBadgeText())
+    }
+
+    @Test
+    fun testConnectionBadgeText_simulation() {
+        val status = AccountStatusResponse(
+            status = "CONNECTED",
+            server = "Darwinex-Live",
+            mockMode = true
+        )
+        assertEquals("Simulation", status.getConnectionBadgeText())
+    }
+
+    @Test
+    fun testConnectionBadgeText_disconnected() {
+        val status = AccountStatusResponse(
+            status = "DISCONNECTED",
+            server = "Darwinex-Demo",
+            mockMode = true
+        )
+        assertEquals("Disconnected", status.getConnectionBadgeText())
+    }
+
+    @Test
+    fun testConnectionBadgeText_error() {
+        val status = AccountStatusResponse(
+            status = "ERROR",
+            server = "Darwinex-Live",
+            mockMode = false,
+            lastError = "Terminal not running"
+        )
+        assertEquals("Disconnected", status.getConnectionBadgeText())
+    }
+
+    @Test
+    fun testConnectionBadgeText_null() {
+        val status: AccountStatusResponse? = null
+        assertEquals("Disconnected", status.getConnectionBadgeText())
+    }
 }
+

--- a/scripts/run-e2e-tests.ps1
+++ b/scripts/run-e2e-tests.ps1
@@ -191,6 +191,19 @@ if ($Tags.Count -gt 0) {
 # 6. Execute Maestro Flows
 Write-Host "`n[4/4] Running Maestro flows ($Flow)..." -ForegroundColor Yellow
 
+$BackendProcess = $null
+try {
+    $TestHttp = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/v1/strategy/status" -TimeoutSec 2 -ErrorAction SilentlyContinue
+} catch {
+    $TestHttp = $null
+}
+
+if (-not $TestHttp) {
+    Write-Host "Starting local FastAPI gateway on 0.0.0.0:8000 for E2E tests..." -ForegroundColor Cyan
+    $BackendProcess = Start-Process -FilePath "python" -ArgumentList "-m", "uvicorn", "api_gateway.main:app", "--host", "0.0.0.0", "--port", "8000" -PassThru -WindowStyle Hidden
+    Start-Sleep -Seconds 3
+}
+
 $FlowFiles = @()
 if (Test-Path $Flow -PathType Container) {
     $FlowFiles = Get-ChildItem -Path $Flow -Filter "*.yaml" | Sort-Object Name
@@ -221,38 +234,45 @@ Write-Host "Discovered $($FlowFiles.Count) active flow(s) to execute." -Foregrou
 $ExecutionResults = @()
 $OverallPassed = $true
 
-foreach ($flowFile in $FlowFiles) {
-    Write-Host "`nRunning flow: $($flowFile.Name)..." -ForegroundColor Cyan
-    $MaestroArgs = @("test", $flowFile.FullName)
-    
-    $FlowPassed = $true
-    try {
-        & $MaestroPath @MaestroArgs
-        if ($LASTEXITCODE -ne 0) { $FlowPassed = $false }
-    } catch {
-        $FlowPassed = $false
+try {
+    foreach ($flowFile in $FlowFiles) {
+        Write-Host "`nRunning flow: $($flowFile.Name)..." -ForegroundColor Cyan
+        $MaestroArgs = @("test", $flowFile.FullName)
+        
+        $FlowPassed = $true
+        try {
+            & $MaestroPath @MaestroArgs
+            if ($LASTEXITCODE -ne 0) { $FlowPassed = $false }
+        } catch {
+            $FlowPassed = $false
+        }
+        
+        if (-not $FlowPassed) {
+            $OverallPassed = $false
+            Write-Host "Flow failed: $($flowFile.Name)" -ForegroundColor Red
+            
+            $ScreenshotName = "failure-$($flowFile.BaseName).png"
+            if (!(Test-Path "docs\screenshots")) { New-Item -ItemType Directory -Path "docs\screenshots" | Out-Null }
+            & $AdbPath -s $OnlineDevice exec-out screencap -p > "docs\screenshots\$ScreenshotName"
+            
+            $ExecutionResults += [PSCustomObject]@{
+                flow = $flowFile.Name
+                passed = $false
+                screenshot = $ScreenshotName
+            }
+        } else {
+            Write-Host "Flow passed: $($flowFile.Name)" -ForegroundColor Green
+            $ExecutionResults += [PSCustomObject]@{
+                flow = $flowFile.Name
+                passed = $true
+                screenshot = $null
+            }
+        }
     }
-    
-    if (-not $FlowPassed) {
-        $OverallPassed = $false
-        Write-Host "Flow failed: $($flowFile.Name)" -ForegroundColor Red
-        
-        $ScreenshotName = "failure-$($flowFile.BaseName).png"
-        if (!(Test-Path "docs\screenshots")) { New-Item -ItemType Directory -Path "docs\screenshots" | Out-Null }
-        & $AdbPath -s $OnlineDevice exec-out screencap -p > "docs\screenshots\$ScreenshotName"
-        
-        $ExecutionResults += [PSCustomObject]@{
-            flow = $flowFile.Name
-            passed = $false
-            screenshot = $ScreenshotName
-        }
-    } else {
-        Write-Host "Flow passed: $($flowFile.Name)" -ForegroundColor Green
-        $ExecutionResults += [PSCustomObject]@{
-            flow = $flowFile.Name
-            passed = $true
-            screenshot = $null
-        }
+} finally {
+    if ($BackendProcess -and -not $BackendProcess.HasExited) {
+        Write-Host "Stopping background FastAPI gateway process..." -ForegroundColor DarkGray
+        Stop-Process -Id $BackendProcess.Id -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -267,3 +287,4 @@ if ($OverallPassed) {
     Write-Host " [FAIL] Some E2E flows failed. See execution summary." -ForegroundColor Red
 }
 Write-Host "==========================================" -ForegroundColor Cyan
+

--- a/scripts/run-e2e-tests.ps1
+++ b/scripts/run-e2e-tests.ps1
@@ -86,6 +86,9 @@ if (-not $Devices) {
     }
     Write-Host "Waiting for device to boot..." -ForegroundColor Yellow
     & $AdbPath wait-for-device
+    while ((& $AdbPath shell getprop sys.boot_completed).Trim() -ne "1") {
+        Start-Sleep -Seconds 2
+    }
 }
 
 $OnlineDevice = (& $AdbPath devices | Where-Object { $_ -match "\bdevice$" } | Select-Object -First 1).Split("`t")[0]
@@ -192,15 +195,20 @@ if ($Tags.Count -gt 0) {
 Write-Host "`n[4/4] Running Maestro flows ($Flow)..." -ForegroundColor Yellow
 
 $BackendProcess = $null
+$BackendRunning = $false
 try {
-    $TestHttp = Invoke-WebRequest -Uri "http://127.0.0.1:8000/api/v1/strategy/status" -TimeoutSec 2 -ErrorAction SilentlyContinue
+    $curlTest = & curl.exe -s --max-time 1 http://127.0.0.1:8000/api/v1/strategy/status 2>$null
+    if ($curlTest -and $curlTest.Contains("strategy_name")) {
+        $BackendRunning = $true
+    }
 } catch {
-    $TestHttp = $null
+    $BackendRunning = $false
 }
 
-if (-not $TestHttp) {
+if (-not $BackendRunning) {
     Write-Host "Starting local FastAPI gateway on 0.0.0.0:8000 for E2E tests..." -ForegroundColor Cyan
-    $BackendProcess = Start-Process -FilePath "python" -ArgumentList "-m", "uvicorn", "api_gateway.main:app", "--host", "0.0.0.0", "--port", "8000" -PassThru -WindowStyle Hidden
+    $RepoRoot = (Resolve-Path "$PSScriptRoot\..").Path
+    $BackendProcess = Start-Process -FilePath "python" -ArgumentList "-m", "uvicorn", "api_gateway.main:app", "--host", "0.0.0.0", "--port", "8000" -WorkingDirectory $RepoRoot -PassThru -WindowStyle Hidden
     Start-Sleep -Seconds 3
 }
 
@@ -268,6 +276,7 @@ try {
                 screenshot = $null
             }
         }
+        Start-Sleep -Seconds 1
     }
 } finally {
     if ($BackendProcess -and -not $BackendProcess.HasExited) {


### PR DESCRIPTION
## Mission Plan: Android Dashboard Live Connection Telemetry Badge

### Context & Objective
Connects and displays real-time connection status telemetry on the mobile Dashboard alongside strategy status and account equity metrics under parent story #4.

### What Changed
1. **DashboardScreen.kt**:
   - Added live connection status badge dynamically reflecting state:
     - \Connected (Live)\ (when connected to live terminal with \mock_mode = false\)
     - \Connected (Demo)\ (when connected to demo server with \mock_mode = false\)
     - \Simulation\ (when \mock_mode = true\)
     - \Disconnected\ (when status is \DISCONNECTED\, \ERROR\, or gateway unreachable)
   - Displayed active Account ID in the account summary header.
   - Preserved strategy status badge alongside connection telemetry badge without screen instability.
2. **MainActivity.kt**:
   - Extended \etchTelemetry()\ to query \GET /api/v1/account/status\ via \piService.getAccountStatus()\.
   - Added polling interval in \LaunchedEffect(Unit)\ and immediate telemetry refresh on tab selection changes.
3. **Models.kt**:
   - Added \getConnectionBadgeText()\ extension on \AccountStatusResponse\ to map server, mode, and status safely.
4. **ModelsTest.kt**:
   - Added unit test cases verifying badge text derivations for live connected, demo connected, simulation, error, disconnected, and null states.
5. **E2E & Build**:
   - Fixed snapshot \pplicationId\ in \uild.gradle.kts\.
   - Updated \scripts/run-e2e-tests.ps1\ to automatically start the local FastAPI gateway on port 8000 during test flow execution.
   - Updated \CHANGELOG.md\ under \[Unreleased]\.

### Verification & Test Results
- **Android Unit Tests**: \	estSnapshotDebugUnitTest\ passed 100% (22 tasks, BUILD SUCCESSFUL).
- **Backend Tests**: \pytest api_gateway/tests strategy_engine/tests\ passed 100% (12 passed).
- **Maestro E2E Tests**: \un-e2e-tests.ps1 -Delta\ passed 100% (5 flows executed and passed).

Part of parent story #4.
Closes #7