### PR TITLE
Add concurrency lock around global_config/connector mutations in /connect and /status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **API Gateway Test Isolation Fixture & Deterministic Test Execution**:
   - Added `api_gateway/tests/conftest.py` with an autouse `reset_shared_state` fixture resetting `connector`, `global_config` singleton, and `current_status` before and after each test.
   - Added `pytest-randomly>=3.0.0` to `api_gateway/requirements.txt` to enforce order-independent and deterministic test execution across random seeds.
+- **Thread Safety & Concurrency Locking for Shared Connector and Global Config Singleton**:
+  - Introduced shared `_state_lock = threading.Lock()` in `api_gateway/routes_strategy.py` guarding `global_config` and `connector` singleton mutations and reads across endpoints.
+  - Protected `connect_account`, `get_connection_status`, `get_account_info`, `get_positions`, and `get_darwinex_stats` in `api_gateway/routes_account.py` with `_state_lock` to ensure atomic state updates and prevent torn reads during concurrent requests.
+  - Enhanced `MT5Connector` in `strategy_engine/mt5_connector.py` with an internal `threading.RLock()` guarding `initialize`, `disconnect`, `get_connection_status`, `get_account_info`, `get_open_positions`, `execute_order`, and `close_all_positions`.
+  - Added concurrency test suites in `api_gateway/tests/test_api.py` (`test_concurrent_account_connect`, `test_concurrent_connect_and_status`) and `strategy_engine/tests/test_strategy.py` (`test_mt5_connector_concurrency`).
 - **Android Dashboard Live Connection Telemetry Badge**:
   - Updated `DashboardScreen.kt` with live connection status badge (`Connected (Live)`, `Connected (Demo)`, `Simulation`, `Disconnected`) and Account ID display sourced from connection telemetry alongside strategy status.
   - Extended `MainActivity.kt` telemetry polling loop (`LaunchedEffect`) and tab-switch triggers to fetch `GET /api/v1/account/status` via `ApiService.getAccountStatus()` and propagate live status to `DashboardScreen`.

--- a/api_gateway/routes_account.py
+++ b/api_gateway/routes_account.py
@@ -17,70 +17,75 @@ from strategy_engine.models import (
 router = APIRouter(prefix="/api/v1/account", tags=["Account & Telemetry"])
 
 # Use shared connector from routes_strategy
-from .routes_strategy import connector, global_config
+from .routes_strategy import connector, global_config, _state_lock
 
 
 @router.post("/connect", response_model=AccountConnectResponse)
 def connect_account(request: AccountConnectRequest) -> AccountConnectResponse:
-    global_config.mt5_login = request.login
-    global_config.mt5_password = request.password
-    global_config.mt5_server = request.server
-    if request.path:
-        global_config.mt5_path = request.path
-    global_config.mock_mode = request.mock_mode
+    with _state_lock:
+        global_config.mt5_login = request.login
+        global_config.mt5_password = request.password
+        global_config.mt5_server = request.server
+        if request.path:
+            global_config.mt5_path = request.path
+        global_config.mock_mode = request.mock_mode
 
-    success, message = connector.initialize()
-    if not success:
+        success, message = connector.initialize()
+        if not success:
+            return AccountConnectResponse(
+                status="ERROR",
+                message=message,
+                login=request.login,
+                server=request.server,
+                trade_mode="DEMO" if "demo" in request.server.lower() else "REAL",
+                balance=0.0,
+                currency="USD",
+                account_info=None,
+                error=message,
+            )
+
+        acc = connector.get_account_info()
         return AccountConnectResponse(
-            status="ERROR",
+            status="CONNECTED",
             message=message,
-            login=request.login,
-            server=request.server,
-            trade_mode="DEMO" if "demo" in request.server.lower() else "REAL",
-            balance=0.0,
-            currency="USD",
-            account_info=None,
-            error=message,
+            login=acc.login,
+            server=acc.server,
+            trade_mode=acc.trade_mode,
+            balance=acc.balance,
+            currency=acc.currency,
+            account_info=acc,
+            error=None,
         )
-
-    acc = connector.get_account_info()
-    return AccountConnectResponse(
-        status="CONNECTED",
-        message=message,
-        login=acc.login,
-        server=acc.server,
-        trade_mode=acc.trade_mode,
-        balance=acc.balance,
-        currency=acc.currency,
-        account_info=acc,
-        error=None,
-    )
 
 
 @router.get("/status", response_model=ConnectionStatus)
 def get_connection_status() -> ConnectionStatus:
-    return connector.get_connection_status()
+    with _state_lock:
+        return connector.get_connection_status()
 
 
 @router.get("/info", response_model=AccountInfo)
 def get_account_info() -> AccountInfo:
-    return connector.get_account_info()
+    with _state_lock:
+        return connector.get_account_info()
 
 
 @router.get("/positions", response_model=List[Position])
 def get_positions() -> List[Position]:
-    return connector.get_open_positions()
+    with _state_lock:
+        return connector.get_open_positions()
 
 
 @router.get("/darwinex-stats")
 def get_darwinex_stats() -> Dict[str, Any]:
-    acc = connector.get_account_info()
-    return {
-        "darwin_symbol": "DWR.4.1",
-        "d_score": acc.d_score or 78.2,
-        "investor_capital_allocated_eur": 30000.0,
-        "return_pct_monthly": 4.15,
-        "max_drawdown_pct": 2.10,
-        "var_95_pct": 1.85,
-        "darwinex_zero_status": "CALIBRATION_PASSED"
-    }
+    with _state_lock:
+        acc = connector.get_account_info()
+        return {
+            "darwin_symbol": "DWR.4.1",
+            "d_score": acc.d_score or 78.2,
+            "investor_capital_allocated_eur": 30000.0,
+            "return_pct_monthly": 4.15,
+            "max_drawdown_pct": 2.10,
+            "var_95_pct": 1.85,
+            "darwinex_zero_status": "CALIBRATION_PASSED"
+        }

--- a/api_gateway/routes_strategy.py
+++ b/api_gateway/routes_strategy.py
@@ -1,6 +1,7 @@
 """
 Strategy control endpoints for starting, pausing, updating parameters, and triggering emergency kill switch.
 """
+import threading
 from fastapi import APIRouter, HTTPException, Depends
 from typing import Dict, Any
 
@@ -10,7 +11,8 @@ from strategy_engine.mt5_connector import MT5Connector
 
 router = APIRouter(prefix="/api/v1/strategy", tags=["Strategy Controls"])
 
-# Shared runtime state
+# Shared runtime state & concurrency lock
+_state_lock = threading.Lock()
 global_config = StrategyConfig(mock_mode=True)
 connector = MT5Connector(global_config)
 connector.initialize()
@@ -20,57 +22,63 @@ current_status = StrategyStatus.IDLE
 
 @router.get("/status")
 def get_strategy_status() -> Dict[str, Any]:
-    acc = connector.get_account_info()
-    positions = connector.get_open_positions()
-    return {
-        "status": current_status.value,
-        "strategy_name": global_config.strategy_name,
-        "symbol": global_config.symbol,
-        "mock_mode": global_config.mock_mode,
-        "open_positions_count": len(positions),
-        "account_balance": acc.balance,
-        "account_equity": acc.equity,
-        "d_score": acc.d_score
-    }
+    with _state_lock:
+        acc = connector.get_account_info()
+        positions = connector.get_open_positions()
+        return {
+            "status": current_status.value,
+            "strategy_name": global_config.strategy_name,
+            "symbol": global_config.symbol,
+            "mock_mode": global_config.mock_mode,
+            "open_positions_count": len(positions),
+            "account_balance": acc.balance,
+            "account_equity": acc.equity,
+            "d_score": acc.d_score
+        }
 
 
 @router.post("/start")
 def start_strategy() -> Dict[str, Any]:
     global current_status
-    current_status = StrategyStatus.RUNNING
-    return {"message": "Strategy started successfully", "status": current_status.value}
+    with _state_lock:
+        current_status = StrategyStatus.RUNNING
+        return {"message": "Strategy started successfully", "status": current_status.value}
 
 
 @router.post("/pause")
 def pause_strategy() -> Dict[str, Any]:
     global current_status
-    current_status = StrategyStatus.PAUSED
-    return {"message": "Strategy paused", "status": current_status.value}
+    with _state_lock:
+        current_status = StrategyStatus.PAUSED
+        return {"message": "Strategy paused", "status": current_status.value}
 
 
 @router.post("/stop")
 def stop_strategy() -> Dict[str, Any]:
     global current_status
-    current_status = StrategyStatus.STOPPED
-    return {"message": "Strategy stopped", "status": current_status.value}
+    with _state_lock:
+        current_status = StrategyStatus.STOPPED
+        return {"message": "Strategy stopped", "status": current_status.value}
 
 
 @router.post("/kill-switch")
 def trigger_kill_switch() -> Dict[str, Any]:
     global current_status
-    closed_count, msg = connector.close_all_positions()
-    current_status = StrategyStatus.PAUSED
-    return {
-        "message": "Emergency Kill Switch Activated",
-        "positions_closed": closed_count,
-        "detail": msg,
-        "status": current_status.value
-    }
+    with _state_lock:
+        closed_count, msg = connector.close_all_positions()
+        current_status = StrategyStatus.PAUSED
+        return {
+            "message": "Emergency Kill Switch Activated",
+            "positions_closed": closed_count,
+            "detail": msg,
+            "status": current_status.value
+        }
 
 
 @router.post("/config")
 def update_config(new_config: Dict[str, Any]) -> Dict[str, Any]:
-    for key, value in new_config.items():
-        if hasattr(global_config, key):
-            setattr(global_config, key, value)
-    return {"message": "Config updated", "current_config": global_config.model_dump()}
+    with _state_lock:
+        for key, value in new_config.items():
+            if hasattr(global_config, key):
+                setattr(global_config, key, value)
+        return {"message": "Config updated", "current_config": global_config.model_dump()}

--- a/api_gateway/tests/test_api.py
+++ b/api_gateway/tests/test_api.py
@@ -187,3 +187,96 @@ def test_account_connect_explicit_path_overrides_config():
     )
     assert resp.status_code == 200
     assert global_config.mt5_path == explicit_path
+
+
+def test_concurrent_account_connect():
+    """
+    Verifies that concurrent POST /api/v1/account/connect requests maintain atomicity
+    and never produce a torn state in global_config or connector.
+    """
+    import concurrent.futures
+    from api_gateway.routes_strategy import global_config, connector
+
+    def send_connect(i: int):
+        login_val = 100000 + i
+        server_val = f"Darwinex-Server-{i}"
+        resp = client.post(
+            "/api/v1/account/connect",
+            json={
+                "login": login_val,
+                "password": f"pwd-{i}",
+                "server": server_val,
+                "mock_mode": True
+            }
+        )
+        return resp.status_code, resp.json()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(send_connect, i) for i in range(20)]
+        results = [f.result() for f in futures]
+
+    for status_code, data in results:
+        assert status_code == 200
+        assert data["status"] == "CONNECTED"
+        assert data["error"] is None
+
+    # Verify that final global_config and connector state match one atomic request
+    acc_info = connector.get_account_info()
+    assert global_config.mt5_login == acc_info.login
+    assert global_config.mt5_server == acc_info.server
+    # Verify login and server have matching index (no torn fields)
+    if global_config.mt5_login >= 100000:
+        idx = global_config.mt5_login - 100000
+        assert global_config.mt5_server == f"Darwinex-Server-{idx}"
+
+
+def test_concurrent_connect_and_status():
+    """
+    Verifies that GET /api/v1/account/status concurrent with POST /api/v1/account/connect
+    never observes a torn/partial state (e.g. CONNECTED with None connected_at or stale error).
+    """
+    import concurrent.futures
+    import threading
+
+    stop_event = threading.Event()
+    status_observations = []
+
+    def status_poller():
+        while not stop_event.is_set():
+            resp = client.get("/api/v1/account/status")
+            if resp.status_code == 200:
+                status_observations.append(resp.json())
+
+    def connect_worker(i: int):
+        login_val = 200000 + i
+        server_val = f"Darwinex-Demo-{i}"
+        return client.post(
+            "/api/v1/account/connect",
+            json={
+                "login": login_val,
+                "password": f"pwd-{i}",
+                "server": server_val,
+                "mock_mode": True
+            }
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        poller_future = executor.submit(status_poller)
+        connect_futures = [executor.submit(connect_worker, i) for i in range(15)]
+        for f in concurrent.futures.as_completed(connect_futures):
+            res = f.result()
+            assert res.status_code == 200
+        stop_event.set()
+        poller_future.result()
+
+    assert len(status_observations) > 0
+    for obs in status_observations:
+        if obs["status"] == "CONNECTED":
+            assert obs["connected_at"] is not None
+            assert obs["last_error"] is None
+            if obs["account_info"] is not None:
+                login_val = obs["account_info"]["login"]
+                if isinstance(login_val, int) and 200000 <= login_val < 200020:
+                    idx = login_val - 200000
+                    assert obs["server"] == f"Darwinex-Demo-{idx}"
+

--- a/strategy_engine/mt5_connector.py
+++ b/strategy_engine/mt5_connector.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Tuple
 from datetime import datetime
 import os
 import platform
+import threading
 import time
 
 from .config import StrategyConfig
@@ -24,6 +25,7 @@ if platform.system() == "Windows":
 class MT5Connector:
     def __init__(self, config: StrategyConfig):
         self.config = config
+        self._lock = threading.RLock()
         self.is_connected = False
         self.connected_at: Optional[datetime] = None
         self.last_error: Optional[str] = None
@@ -37,40 +39,19 @@ class MT5Connector:
         """
         Initializes connection to MT5 terminal or starts mock mode.
         """
-        start_time = time.perf_counter()
-        if self.config.mock_mode or not HAS_MT5:
-            self.is_connected = True
-            self.connected_at = datetime.utcnow()
-            self.last_error = None
-            self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
-            return True, "Initialized MT5 in MOCK / Simulation Mode"
+        with self._lock:
+            start_time = time.perf_counter()
+            if self.config.mock_mode or not HAS_MT5:
+                self.is_connected = True
+                self.connected_at = datetime.utcnow()
+                self.last_error = None
+                self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
+                return True, "Initialized MT5 in MOCK / Simulation Mode"
 
-        # Live MT5 execution branch
-        try:
-            init_success = mt5.initialize(
-                path=self.config.mt5_path,
-                login=self.config.mt5_login,
-                password=self.config.mt5_password,
-                server=self.config.mt5_server
-            )
-        except Exception as e:
-            self.is_connected = False
-            self.connected_at = None
-            self.last_error = f"MT5 initialize exception: {e}"
-            self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
-            return False, self.last_error
-
-        self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
-        if not init_success:
-            error_code = mt5.last_error()
-            self.is_connected = False
-            self.connected_at = None
-            self.last_error = f"MT5 initialize failed: {error_code}"
-            return False, self.last_error
-
-        if self.config.mt5_login:
+            # Live MT5 execution branch
             try:
-                login_success = mt5.login(
+                init_success = mt5.initialize(
+                    path=self.config.mt5_path,
                     login=self.config.mt5_login,
                     password=self.config.mt5_password,
                     server=self.config.mt5_server
@@ -78,192 +59,220 @@ class MT5Connector:
             except Exception as e:
                 self.is_connected = False
                 self.connected_at = None
-                self.last_error = f"MT5 login exception: {e}"
+                self.last_error = f"MT5 initialize exception: {e}"
+                self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
                 return False, self.last_error
 
-            if not login_success:
+            self.latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
+            if not init_success:
                 error_code = mt5.last_error()
                 self.is_connected = False
                 self.connected_at = None
-                self.last_error = f"MT5 login failed: {error_code}"
+                self.last_error = f"MT5 initialize failed: {error_code}"
                 return False, self.last_error
 
-        self.is_connected = True
-        self.connected_at = datetime.utcnow()
-        self.last_error = None
-        return True, "Connected to MetaTrader 5 live terminal"
+            if self.config.mt5_login:
+                try:
+                    login_success = mt5.login(
+                        login=self.config.mt5_login,
+                        password=self.config.mt5_password,
+                        server=self.config.mt5_server
+                    )
+                except Exception as e:
+                    self.is_connected = False
+                    self.connected_at = None
+                    self.last_error = f"MT5 login exception: {e}"
+                    return False, self.last_error
+
+                if not login_success:
+                    error_code = mt5.last_error()
+                    self.is_connected = False
+                    self.connected_at = None
+                    self.last_error = f"MT5 login failed: {error_code}"
+                    return False, self.last_error
+
+            self.is_connected = True
+            self.connected_at = datetime.utcnow()
+            self.last_error = None
+            return True, "Connected to MetaTrader 5 live terminal"
 
     def disconnect(self) -> Tuple[bool, str]:
         """
         Disconnects from MT5 terminal.
         """
-        if HAS_MT5 and not self.config.mock_mode:
-            try:
-                mt5.shutdown()
-            except Exception as e:
-                self.last_error = str(e)
-        self.is_connected = False
-        self.connected_at = None
-        return True, "Disconnected from MetaTrader 5"
+        with self._lock:
+            if HAS_MT5 and not self.config.mock_mode:
+                try:
+                    mt5.shutdown()
+                except Exception as e:
+                    self.last_error = str(e)
+            self.is_connected = False
+            self.connected_at = None
+            return True, "Disconnected from MetaTrader 5"
 
     def get_connection_status(self) -> ConnectionStatus:
         """
         Returns connection state, latency, server mode, and diagnostic info.
         """
-        status_str = "CONNECTED" if self.is_connected else ("ERROR" if self.last_error else "DISCONNECTED")
-        acc = self.get_account_info() if self.is_connected else None
-        return ConnectionStatus(
-            status=status_str,
-            server=self.config.mt5_server,
-            mock_mode=self.config.mock_mode,
-            latency_ms=self.latency_ms,
-            connected_at=self.connected_at,
-            last_error=self.last_error,
-            account_info=acc
-        )
+        with self._lock:
+            status_str = "CONNECTED" if self.is_connected else ("ERROR" if self.last_error else "DISCONNECTED")
+            acc = self.get_account_info() if self.is_connected else None
+            return ConnectionStatus(
+                status=status_str,
+                server=self.config.mt5_server,
+                mock_mode=self.config.mock_mode,
+                latency_ms=self.latency_ms,
+                connected_at=self.connected_at,
+                last_error=self.last_error,
+                account_info=acc
+            )
 
     def get_account_info(self) -> AccountInfo:
         """
         Fetches live account statistics or returns mock account data.
         """
-        if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
-            floating_pnl = sum(p.pnl for p in self._mock_positions)
-            trade_mode = "DEMO" if "demo" in self.config.mt5_server.lower() else "REAL"
+        with self._lock:
+            if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
+                floating_pnl = sum(p.pnl for p in self._mock_positions)
+                trade_mode = "DEMO" if "demo" in self.config.mt5_server.lower() else "REAL"
+                return AccountInfo(
+                    login=self.config.mt5_login or 1234567,
+                    trade_mode=trade_mode,
+                    server=self.config.mt5_server,
+                    balance=self._mock_balance,
+                    equity=self._mock_balance + floating_pnl,
+                    margin=len(self._mock_positions) * 200.0,
+                    free_margin=self._mock_balance + floating_pnl - (len(self._mock_positions) * 200.0),
+                    profit=floating_pnl,
+                    d_score=78.2
+                )
+
+            acc = mt5.account_info()
+            if acc is None:
+                return AccountInfo()
+
             return AccountInfo(
-                login=self.config.mt5_login or 1234567,
-                trade_mode=trade_mode,
-                server=self.config.mt5_server,
-                balance=self._mock_balance,
-                equity=self._mock_balance + floating_pnl,
-                margin=len(self._mock_positions) * 200.0,
-                free_margin=self._mock_balance + floating_pnl - (len(self._mock_positions) * 200.0),
-                profit=floating_pnl,
+                login=acc.login,
+                trade_mode="DEMO" if acc.trade_mode == 0 else "REAL",
+                server=acc.server,
+                balance=acc.balance,
+                equity=acc.equity,
+                margin=acc.margin,
+                free_margin=acc.margin_free,
+                profit=acc.profit,
+                currency=acc.currency,
                 d_score=78.2
             )
-
-        acc = mt5.account_info()
-        if acc is None:
-            return AccountInfo()
-
-        return AccountInfo(
-            login=acc.login,
-            trade_mode="DEMO" if acc.trade_mode == 0 else "REAL",
-            server=acc.server,
-            balance=acc.balance,
-            equity=acc.equity,
-            margin=acc.margin,
-            free_margin=acc.margin_free,
-            profit=acc.profit,
-            currency=acc.currency,
-            d_score=78.2
-        )
 
     def get_open_positions(self) -> List[Position]:
         """
         Returns list of active open positions for strategy magic number.
         """
-        if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
-            return self._mock_positions
+        with self._lock:
+            if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
+                return list(self._mock_positions)
 
-        mt5_positions = mt5.positions_get(symbol=self.config.symbol)
-        if mt5_positions is None:
-            return []
+            mt5_positions = mt5.positions_get(symbol=self.config.symbol)
+            if mt5_positions is None:
+                return []
 
-        positions = []
-        for pos in mt5_positions:
-            if pos.magic == self.config.magic_number:
-                order_type = OrderType.BUY if pos.type == 0 else OrderType.SELL
-                positions.append(Position(
-                    ticket=pos.ticket,
-                    symbol=pos.symbol,
-                    order_type=order_type,
-                    volume=pos.volume,
-                    open_price=pos.price_open,
-                    current_price=pos.price_current,
-                    sl=pos.sl,
-                    tp=pos.tp,
-                    pnl=pos.profit,
-                    magic=pos.magic
-                ))
-        return positions
+            positions = []
+            for pos in mt5_positions:
+                if pos.magic == self.config.magic_number:
+                    order_type = OrderType.BUY if pos.type == 0 else OrderType.SELL
+                    positions.append(Position(
+                        ticket=pos.ticket,
+                        symbol=pos.symbol,
+                        order_type=order_type,
+                        volume=pos.volume,
+                        open_price=pos.price_open,
+                        current_price=pos.price_current,
+                        sl=pos.sl,
+                        tp=pos.tp,
+                        pnl=pos.profit,
+                        magic=pos.magic
+                    ))
+            return positions
 
     def execute_order(self, signal: TradeSignal) -> Tuple[bool, str]:
         """
         Executes market order on MT5 terminal or updates mock state.
         """
-        if signal.signal_type not in (SignalType.ENTER_LONG, SignalType.ENTER_SHORT):
-            return False, "Invalid signal for order execution"
+        with self._lock:
+            if signal.signal_type not in (SignalType.ENTER_LONG, SignalType.ENTER_SHORT):
+                return False, "Invalid signal for order execution"
 
-        if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
-            ticket = self._mock_ticket_counter
-            self._mock_ticket_counter += 1
-            order_type = OrderType.BUY if signal.signal_type == SignalType.ENTER_LONG else OrderType.SELL
-            
-            pos = Position(
-                ticket=ticket,
-                symbol=signal.symbol,
-                order_type=order_type,
-                volume=signal.lot_size,
-                open_price=signal.price,
-                current_price=signal.price,
-                sl=signal.stop_loss or 0.0,
-                tp=signal.take_profit or 0.0,
-                pnl=0.0,
-                magic=self.config.magic_number
-            )
-            self._mock_positions.append(pos)
-            return True, f"Mock Order Executed: Ticket #{ticket} {order_type.value} {signal.lot_size} lots @ {signal.price}"
+            if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
+                ticket = self._mock_ticket_counter
+                self._mock_ticket_counter += 1
+                order_type = OrderType.BUY if signal.signal_type == SignalType.ENTER_LONG else OrderType.SELL
+                
+                pos = Position(
+                    ticket=ticket,
+                    symbol=signal.symbol,
+                    order_type=order_type,
+                    volume=signal.lot_size,
+                    open_price=signal.price,
+                    current_price=signal.price,
+                    sl=signal.stop_loss or 0.0,
+                    tp=signal.take_profit or 0.0,
+                    pnl=0.0,
+                    magic=self.config.magic_number
+                )
+                self._mock_positions.append(pos)
+                return True, f"Mock Order Executed: Ticket #{ticket} {order_type.value} {signal.lot_size} lots @ {signal.price}"
 
-        # MT5 Live Order execution
-        order_type_mt5 = mt5.ORDER_TYPE_BUY if signal.signal_type == SignalType.ENTER_LONG else mt5.ORDER_TYPE_SELL
-        request = {
-            "action": mt5.TRADE_ACTION_DEAL,
-            "symbol": signal.symbol,
-            "volume": signal.lot_size,
-            "type": order_type_mt5,
-            "price": signal.price,
-            "sl": signal.stop_loss or 0.0,
-            "tp": signal.take_profit or 0.0,
-            "magic": self.config.magic_number,
-            "comment": f"DarwinTrader {signal.reason[:20]}",
-            "type_time": mt5.ORDER_TIME_GTC,
-            "type_filling": mt5.ORDER_FILLING_IOC,
-        }
+            # MT5 Live Order execution
+            order_type_mt5 = mt5.ORDER_TYPE_BUY if signal.signal_type == SignalType.ENTER_LONG else mt5.ORDER_TYPE_SELL
+            request = {
+                "action": mt5.TRADE_ACTION_DEAL,
+                "symbol": signal.symbol,
+                "volume": signal.lot_size,
+                "type": order_type_mt5,
+                "price": signal.price,
+                "sl": signal.stop_loss or 0.0,
+                "tp": signal.take_profit or 0.0,
+                "magic": self.config.magic_number,
+                "comment": f"DarwinTrader {signal.reason[:20]}",
+                "type_time": mt5.ORDER_TIME_GTC,
+                "type_filling": mt5.ORDER_FILLING_IOC,
+            }
 
-        result = mt5.order_send(request)
-        if result is None or result.retcode != mt5.TRADE_RETCODE_DONE:
-            comment = result.comment if result else "Unknown MT5 error"
-            return False, f"MT5 Order Execution Failed: {comment}"
+            result = mt5.order_send(request)
+            if result is None or result.retcode != mt5.TRADE_RETCODE_DONE:
+                comment = result.comment if result else "Unknown MT5 error"
+                return False, f"MT5 Order Execution Failed: {comment}"
 
-        return True, f"Live MT5 Order Executed: Ticket #{result.order}"
+            return True, f"Live MT5 Order Executed: Ticket #{result.order}"
 
     def close_all_positions(self) -> Tuple[int, str]:
         """
         Emergency Kill Switch: Closes all open positions.
         """
-        closed_count = 0
-        if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
-            closed_count = len(self._mock_positions)
-            self._mock_positions.clear()
-            return closed_count, f"Mock Kill Switch triggered: Closed {closed_count} positions"
+        with self._lock:
+            closed_count = 0
+            if self.config.mock_mode or not HAS_MT5 or not self.is_connected:
+                closed_count = len(self._mock_positions)
+                self._mock_positions.clear()
+                return closed_count, f"Mock Kill Switch triggered: Closed {closed_count} positions"
 
-        positions = self.get_open_positions()
-        for pos in positions:
-            order_type_mt5 = mt5.ORDER_TYPE_SELL if pos.order_type == OrderType.BUY else mt5.ORDER_TYPE_BUY
-            request = {
-                "action": mt5.TRADE_ACTION_DEAL,
-                "symbol": pos.symbol,
-                "volume": pos.volume,
-                "type": order_type_mt5,
-                "position": pos.ticket,
-                "price": pos.current_price,
-                "magic": self.config.magic_number,
-                "comment": "Kill Switch Close",
-                "type_time": mt5.ORDER_TIME_GTC,
-                "type_filling": mt5.ORDER_FILLING_IOC,
-            }
-            res = mt5.order_send(request)
-            if res and res.retcode == mt5.TRADE_RETCODE_DONE:
-                closed_count += 1
+            positions = self.get_open_positions()
+            for pos in positions:
+                order_type_mt5 = mt5.ORDER_TYPE_SELL if pos.order_type == OrderType.BUY else mt5.ORDER_TYPE_BUY
+                request = {
+                    "action": mt5.TRADE_ACTION_DEAL,
+                    "symbol": pos.symbol,
+                    "volume": pos.volume,
+                    "type": order_type_mt5,
+                    "position": pos.ticket,
+                    "price": pos.current_price,
+                    "magic": self.config.magic_number,
+                    "comment": "Kill Switch Close",
+                    "type_time": mt5.ORDER_TIME_GTC,
+                    "type_filling": mt5.ORDER_FILLING_IOC,
+                }
+                res = mt5.order_send(request)
+                if res and res.retcode == mt5.TRADE_RETCODE_DONE:
+                    closed_count += 1
 
-        return closed_count, f"Live Kill Switch triggered: Closed {closed_count} open positions"
+            return closed_count, f"Live Kill Switch triggered: Closed {closed_count} open positions"

--- a/strategy_engine/tests/test_strategy.py
+++ b/strategy_engine/tests/test_strategy.py
@@ -185,3 +185,42 @@ def test_account_connect_request_path_default():
     req_custom = AccountConnectRequest(path="C:\\Custom\\MT5\\terminal64.exe")
     assert req_custom.path == "C:\\Custom\\MT5\\terminal64.exe"
 
+
+def test_mt5_connector_concurrency():
+    """
+    Verifies that concurrent calls to MT5Connector (initialize, execute_order,
+    get_connection_status, close_all_positions) are thread-safe and do not corrupt state.
+    """
+    import concurrent.futures
+
+    config = StrategyConfig(mock_mode=True, mt5_server="Darwinex-Demo")
+    connector = MT5Connector(config)
+    connector.initialize()
+
+    def place_orders(worker_id: int):
+        for j in range(5):
+            sig = TradeSignal(
+                symbol="EURUSD",
+                signal_type=SignalType.ENTER_LONG,
+                price=1.0800 + (worker_id * 0.001) + (j * 0.0001),
+                lot_size=0.01,
+                reason=f"worker-{worker_id}"
+            )
+            ok, msg = connector.execute_order(sig)
+            assert ok is True
+            status = connector.get_connection_status()
+            assert status.status == ConnectionState.CONNECTED
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        futures = [executor.submit(place_orders, i) for i in range(5)]
+        for f in concurrent.futures.as_completed(futures):
+            f.result()
+
+    positions = connector.get_open_positions()
+    assert len(positions) == 25
+
+    closed, msg = connector.close_all_positions()
+    assert closed == 25
+    assert len(connector.get_open_positions()) == 0
+
+


### PR DESCRIPTION
### Summary of Changes
- Introduced module-level \_state_lock = threading.Lock()\ in \pi_gateway/routes_strategy.py\ to synchronize access to \global_config\ and \connector\ across FastAPI endpoint worker threads.
- Wrapped all mutation and read sequences in \pi_gateway/routes_account.py\ (\connect_account\, \get_connection_status\, \get_account_info\, \get_positions\, \get_darwinex_stats\) and \pi_gateway/routes_strategy.py\ with \_state_lock\ to avoid partial state observation and race conditions.
- Enhanced \strategy_engine/mt5_connector.py\ with an internal \	hreading.RLock()\ guarding \initialize\, \disconnect\, \get_connection_status\, \get_account_info\, \get_open_positions\, \execute_order\, and \close_all_positions\.
- Added concurrent unit test suites in \pi_gateway/tests/test_api.py\ (\	est_concurrent_account_connect\, \	est_concurrent_connect_and_status\) and \strategy_engine/tests/test_strategy.py\ (\	est_mt5_connector_concurrency\).
- Updated \CHANGELOG.md\ under \[Unreleased]\ with entry details.

### Test Results
- **Python Backend Unit & Concurrency Tests:** 15 passed (\python -m pytest api_gateway/tests strategy_engine/tests\).
- **Android Unit Tests:** All passed (\.\gradlew.bat testSnapshotDebugUnitTest\).

### Related Issues
- Closes #18
- Subtask of parent story #17