### PR TITLE
Add pytest fixture for connector/global_config test isolation and verify order-independent test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **API Gateway Test Isolation Fixture & Deterministic Test Execution**:
+  - Added `api_gateway/tests/conftest.py` with an autouse `reset_shared_state` fixture resetting `connector`, `global_config` singleton, and `current_status` before and after each test.
+  - Added `pytest-randomly>=3.0.0` to `api_gateway/requirements.txt` to enforce order-independent and deterministic test execution across random seeds.
 - **Android Dashboard Live Connection Telemetry Badge**:
   - Updated `DashboardScreen.kt` with live connection status badge (`Connected (Live)`, `Connected (Demo)`, `Simulation`, `Disconnected`) and Account ID display sourced from connection telemetry alongside strategy status.
   - Extended `MainActivity.kt` telemetry polling loop (`LaunchedEffect`) and tab-switch triggers to fetch `GET /api/v1/account/status` via `ApiService.getAccountStatus()` and propagate live status to `DashboardScreen`.

--- a/api_gateway/requirements.txt
+++ b/api_gateway/requirements.txt
@@ -3,4 +3,5 @@ uvicorn>=0.22.0
 websockets>=11.0
 pydantic>=2.0.0
 pytest>=7.0.0
+pytest-randomly>=3.0.0
 httpx>=0.24.0

--- a/api_gateway/tests/conftest.py
+++ b/api_gateway/tests/conftest.py
@@ -1,0 +1,30 @@
+"""
+Pytest configuration and test isolation fixtures for API Gateway tests.
+"""
+import pytest
+from strategy_engine.config import StrategyConfig
+from strategy_engine.models import StrategyStatus
+from api_gateway.routes_strategy import connector, global_config
+import api_gateway.routes_strategy as routes_strategy
+
+
+@pytest.fixture(autouse=True)
+def reset_shared_state():
+    """
+    Autouse fixture that resets module-level connector and global_config singleton
+    state before and after each test for full test isolation.
+    """
+    def _reset():
+        fresh_config = StrategyConfig(mock_mode=True)
+        global_config.__dict__.clear()
+        global_config.__dict__.update(fresh_config.__dict__)
+        if hasattr(global_config, "__pydantic_fields_set__"):
+            global_config.__pydantic_fields_set__.clear()
+            global_config.__pydantic_fields_set__.update(fresh_config.__pydantic_fields_set__)
+        connector.__init__(global_config)
+        connector.initialize()
+        routes_strategy.current_status = StrategyStatus.IDLE
+
+    _reset()
+    yield
+    _reset()


### PR DESCRIPTION
## Summary of Changes
- Created \pi_gateway/tests/conftest.py\ with an autouse \eset_shared_state\ fixture resetting \connector\, \global_config\ singleton, and \current_status\ before and after each test for strict test isolation.
- Added \pytest-randomly>=3.0.0\ to \pi_gateway/requirements.txt\ to enforce order-independent and deterministic test execution across random seeds.
- Updated \CHANGELOG.md\ under \## [Unreleased]\ with details of the test isolation fixture and \pytest-randomly\ dependency.

## Test Results
- Unit Tests:
  - Python tests: \python -m pytest api_gateway/tests strategy_engine/tests\ (12 passed across random seeds: 1, 42, 123, 9999, 20260827).
  - Isolated test execution and explicit inverse execution order (\	est_account_connect_and_status_failure\ followed by \	est_account_connect_and_status_success\) verified passing deterministically.
  - Android Unit Tests: \gradlew.bat testSnapshotDebugUnitTest --no-daemon\ passed successfully.

Parent Story: #17
Closes #19