### PR TITLE
Type ConnectionState enum onto AccountConnectResponse.status and ConnectionStatus.status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- **ConnectionState Enum Typing on Account Connection Models**:
+  - Typed `AccountConnectResponse.status` and `ConnectionStatus.status` as `ConnectionState` enum in `strategy_engine/models.py` to enforce strict validation against allowed states (`CONNECTED`, `DISCONNECTED`, `ERROR`).
+  - Added unit test `test_connection_state_validation` in `strategy_engine/tests/test_strategy.py` verifying serialization and asserting `ValidationError` is raised for invalid status strings.
+
 ### Added
 - **API Gateway Test Isolation Fixture & Deterministic Test Execution**:
   - Added `api_gateway/tests/conftest.py` with an autouse `reset_shared_state` fixture resetting `connector`, `global_config` singleton, and `current_status` before and after each test.

--- a/strategy_engine/models.py
+++ b/strategy_engine/models.py
@@ -103,7 +103,7 @@ class AccountConnectRequest(BaseModel):
 
 
 class AccountConnectResponse(BaseModel):
-    status: str = "CONNECTED"
+    status: ConnectionState = ConnectionState.CONNECTED
     message: str = ""
     login: int = 0
     server: str = "Darwinex-Demo"
@@ -115,7 +115,7 @@ class AccountConnectResponse(BaseModel):
 
 
 class ConnectionStatus(BaseModel):
-    status: str = "DISCONNECTED"
+    status: ConnectionState = ConnectionState.DISCONNECTED
     server: str = "Darwinex-Demo"
     mock_mode: bool = True
     latency_ms: float = 0.0

--- a/strategy_engine/tests/test_strategy.py
+++ b/strategy_engine/tests/test_strategy.py
@@ -5,8 +5,19 @@ import pytest
 import pandas as pd
 from datetime import datetime
 
+from pydantic import ValidationError
+
 from strategy_engine.config import StrategyConfig
-from strategy_engine.models import SignalType, TradeSignal, AccountInfo, Position, OrderType
+from strategy_engine.models import (
+    SignalType,
+    TradeSignal,
+    AccountInfo,
+    Position,
+    OrderType,
+    ConnectionState,
+    AccountConnectResponse,
+    ConnectionStatus,
+)
 from strategy_engine.sample_strategy import DarwinTrendStrategy
 from strategy_engine.risk_manager import RiskManager
 from strategy_engine.backtester import Backtester, generate_mock_ohlcv
@@ -136,3 +147,29 @@ def test_mt5_connector_live_init_failure(monkeypatch):
     assert status.status == "ERROR"
     assert status.last_error == msg
     assert status.account_info is None
+
+
+def test_connection_state_validation():
+    for state in [ConnectionState.CONNECTED, ConnectionState.DISCONNECTED, ConnectionState.ERROR]:
+        resp = AccountConnectResponse(status=state)
+        assert resp.status == state
+        assert resp.model_dump()["status"] == state.value
+
+        resp_str = AccountConnectResponse(status=state.value)
+        assert resp_str.status == state
+        assert resp_str.model_dump()["status"] == state.value
+
+        conn = ConnectionStatus(status=state)
+        assert conn.status == state
+        assert conn.model_dump()["status"] == state.value
+
+        conn_str = ConnectionStatus(status=state.value)
+        assert conn_str.status == state
+        assert conn_str.model_dump()["status"] == state.value
+
+    with pytest.raises(ValidationError):
+        AccountConnectResponse(status="BOGUS")
+
+    with pytest.raises(ValidationError):
+        ConnectionStatus(status="BOGUS")
+


### PR DESCRIPTION
## Summary
- Replaced plain \str\ type annotation on \AccountConnectResponse.status\ and \ConnectionStatus.status\ with \ConnectionState\ enum in \strategy_engine/models.py\.
- Enforces strict Pydantic validation on allowed connection states (\CONNECTED\, \DISCONNECTED\, \ERROR\).
- Added unit test \	est_connection_state_validation\ in \strategy_engine/tests/test_strategy.py\ to verify valid serialization and rejection of invalid status values with \ValidationError\.
- Documented changes in \CHANGELOG.md\ under \[Unreleased]\.

## Context
Part of Parent Story #16: Harden Strategy Engine connection models with enum typing and dynamic path resolution.

## Verification
- Unit Tests (Python): \python -m pytest api_gateway/tests strategy_engine/tests\ -> 13 passed
- Unit Tests (Android): \gradlew.bat testSnapshotDebugUnitTest\ -> BUILD SUCCESSFUL

Closes #20