### PR TITLE
Default AccountConnectRequest.path to None with StrategyConfig fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Default AccountConnectRequest.path to None with StrategyConfig Fallback**:
+  - Changed `AccountConnectRequest.path` in `strategy_engine/models.py` (and Android `Models.kt`) to default to `None` instead of a hardcoded path.
+  - Verified route fallback preserves configured `StrategyConfig.mt5_path` when `path` is omitted or `None`, while allowing explicit override.
+  - Added unit and API tests in `strategy_engine/tests/test_strategy.py`, `api_gateway/tests/test_api.py`, and `ModelsTest.kt`.
 - **ConnectionState Enum Typing on Account Connection Models**:
   - Typed `AccountConnectResponse.status` and `ConnectionStatus.status` as `ConnectionState` enum in `strategy_engine/models.py` to enforce strict validation against allowed states (`CONNECTED`, `DISCONNECTED`, `ERROR`).
   - Added unit test `test_connection_state_validation` in `strategy_engine/tests/test_strategy.py` verifying serialization and asserting `ValidationError` is raised for invalid status strings.

--- a/android/app/src/main/java/com/darwintrader/app/data/model/Models.kt
+++ b/android/app/src/main/java/com/darwintrader/app/data/model/Models.kt
@@ -57,7 +57,7 @@ data class AccountConnectRequest(
     @SerializedName("login") val login: Long = 0,
     @SerializedName("password") val password: String = "",
     @SerializedName("server") val server: String = "Darwinex-Demo",
-    @SerializedName("path") val path: String? = "C:\\Program Files\\Darwinex MetaTrader 5\\terminal64.exe",
+    @SerializedName("path") val path: String? = null,
     @SerializedName("mock_mode") val mockMode: Boolean = true
 )
 

--- a/android/app/src/test/java/com/darwintrader/app/ModelsTest.kt
+++ b/android/app/src/test/java/com/darwintrader/app/ModelsTest.kt
@@ -28,6 +28,15 @@ class ModelsTest {
     }
 
     @Test
+    fun testAccountConnectRequestDefaultPath() {
+        val request = AccountConnectRequest(
+            login = 123456L,
+            password = "securePassword"
+        )
+        assertNull(request.path)
+    }
+
+    @Test
     fun testAccountConnectResponseDeserialization_success() {
         val json = """
             {

--- a/api_gateway/tests/test_api.py
+++ b/api_gateway/tests/test_api.py
@@ -133,3 +133,57 @@ def test_account_connect_and_status_failure(monkeypatch):
     assert status_data["mock_mode"] is False
     assert status_data["last_error"] == data["error"]
     assert status_data["account_info"] is None
+
+
+def test_account_connect_path_fallback_preserves_config():
+    from api_gateway.routes_strategy import global_config
+
+    configured_path = "C:\\Configured\\Darwinex MetaTrader 5\\terminal64.exe"
+    global_config.mt5_path = configured_path
+
+    # Calling connect without 'path' field
+    resp = client.post(
+        "/api/v1/account/connect",
+        json={
+            "login": 123456,
+            "password": "pwd",
+            "server": "Darwinex-Demo",
+            "mock_mode": True,
+        },
+    )
+    assert resp.status_code == 200
+    assert global_config.mt5_path == configured_path
+
+    # Calling connect with explicit None 'path'
+    resp_none = client.post(
+        "/api/v1/account/connect",
+        json={
+            "login": 123456,
+            "password": "pwd",
+            "server": "Darwinex-Demo",
+            "path": None,
+            "mock_mode": True,
+        },
+    )
+    assert resp_none.status_code == 200
+    assert global_config.mt5_path == configured_path
+
+
+def test_account_connect_explicit_path_overrides_config():
+    from api_gateway.routes_strategy import global_config
+
+    global_config.mt5_path = "C:\\Default\\Path\\terminal64.exe"
+    explicit_path = "D:\\Custom\\MT5\\terminal64.exe"
+
+    resp = client.post(
+        "/api/v1/account/connect",
+        json={
+            "login": 654321,
+            "password": "pwd",
+            "server": "Darwinex-Demo",
+            "path": explicit_path,
+            "mock_mode": True,
+        },
+    )
+    assert resp.status_code == 200
+    assert global_config.mt5_path == explicit_path

--- a/strategy_engine/models.py
+++ b/strategy_engine/models.py
@@ -98,7 +98,7 @@ class AccountConnectRequest(BaseModel):
     login: int = 0
     password: str = ""
     server: str = "Darwinex-Demo"
-    path: Optional[str] = "C:\\Program Files\\Darwinex MetaTrader 5\\terminal64.exe"
+    path: Optional[str] = None
     mock_mode: bool = True
 
 

--- a/strategy_engine/tests/test_strategy.py
+++ b/strategy_engine/tests/test_strategy.py
@@ -15,6 +15,7 @@ from strategy_engine.models import (
     Position,
     OrderType,
     ConnectionState,
+    AccountConnectRequest,
     AccountConnectResponse,
     ConnectionStatus,
 )
@@ -172,4 +173,15 @@ def test_connection_state_validation():
 
     with pytest.raises(ValidationError):
         ConnectionStatus(status="BOGUS")
+
+
+def test_account_connect_request_path_default():
+    req_default = AccountConnectRequest()
+    assert req_default.path is None
+
+    req_none = AccountConnectRequest(path=None)
+    assert req_none.path is None
+
+    req_custom = AccountConnectRequest(path="C:\\Custom\\MT5\\terminal64.exe")
+    assert req_custom.path == "C:\\Custom\\MT5\\terminal64.exe"
 


### PR DESCRIPTION
## Summary of Changes
- Changed AccountConnectRequest.path in strategy_engine/models.py and Android Models.kt to default to None instead of a hardcoded Windows path.
- Leveraged existing fallback logic in api_gateway/routes_account.py::connect_account to preserve configured StrategyConfig.mt5_path when path is omitted or None, while allowing explicit override.
- Added comprehensive unit and integration tests:
  - strategy_engine/tests/test_strategy.py::test_account_connect_request_path_default
  - api_gateway/tests/test_api.py::test_account_connect_path_fallback_preserves_config
  - api_gateway/tests/test_api.py::test_account_connect_explicit_path_overrides_config
  - android/app/src/test/java/com/darwintrader/app/ModelsTest.kt::testAccountConnectRequestDefaultPath
- Updated CHANGELOG.md following Keep a Changelog guidelines.

## Test Results
- Python Backend Tests: 16 passed (100% green)
- Android Unit Tests: testSnapshotDebugUnitTest BUILD SUCCESSFUL (100% green)

## Parent Story
Ref: #16

Closes #21