### PR TITLE
Add StrategyConfig.reset_from() helper to replace manual pydantic internals manipulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Added unit test `test_connection_state_validation` in `strategy_engine/tests/test_strategy.py` verifying serialization and asserting `ValidationError` is raised for invalid status strings.
 
 ### Added
+- **StrategyConfig.reset_from Helper for Safe Fixture State Reset**:
+  - Added `StrategyConfig.reset_from(other, **overrides)` in `strategy_engine/config.py` enabling bulk resets of live configuration singleton instances without manipulating private Pydantic internals (`__dict__`, `__pydantic_fields_set__`).
+  - Refactored `api_gateway/tests/conftest.py` autouse isolation fixture to use `global_config.reset_from()`.
+  - Added unit tests in `strategy_engine/tests/test_strategy.py` verifying field resets, default fallback, keyword overrides, and idempotency.
 - **API Gateway Test Isolation Fixture & Deterministic Test Execution**:
   - Added `api_gateway/tests/conftest.py` with an autouse `reset_shared_state` fixture resetting `connector`, `global_config` singleton, and `current_status` before and after each test.
   - Added `pytest-randomly>=3.0.0` to `api_gateway/requirements.txt` to enforce order-independent and deterministic test execution across random seeds.

--- a/api_gateway/tests/conftest.py
+++ b/api_gateway/tests/conftest.py
@@ -15,12 +15,7 @@ def reset_shared_state():
     state before and after each test for full test isolation.
     """
     def _reset():
-        fresh_config = StrategyConfig(mock_mode=True)
-        global_config.__dict__.clear()
-        global_config.__dict__.update(fresh_config.__dict__)
-        if hasattr(global_config, "__pydantic_fields_set__"):
-            global_config.__pydantic_fields_set__.clear()
-            global_config.__pydantic_fields_set__.update(fresh_config.__pydantic_fields_set__)
+        global_config.reset_from(StrategyConfig(mock_mode=True))
         connector.__init__(global_config)
         connector.initialize()
         routes_strategy.current_status = StrategyStatus.IDLE

--- a/strategy_engine/config.py
+++ b/strategy_engine/config.py
@@ -36,6 +36,19 @@ class StrategyConfig(BaseModel):
     mt5_server: str = os.getenv("MT5_SERVER", "Darwinex-Demo")
     mt5_path: str = os.getenv("MT5_PATH", "C:\\Program Files\\Darwinex MetaTrader 5\\terminal64.exe")
 
+    def reset_from(self, other: "StrategyConfig | None" = None, **overrides) -> "StrategyConfig":
+        """
+        Reset instance fields to match another StrategyConfig instance or fresh defaults with optional overrides.
+        Avoids directly manipulating private pydantic internals like __dict__ and __pydantic_fields_set__.
+        """
+        if other is not None:
+            source = other.model_copy(update=overrides) if overrides else other
+        else:
+            source = StrategyConfig(**overrides)
+        for key, value in source.model_dump().items():
+            setattr(self, key, value)
+        return self
+
 
 # Default global instance
 default_config = StrategyConfig()

--- a/strategy_engine/tests/test_strategy.py
+++ b/strategy_engine/tests/test_strategy.py
@@ -224,3 +224,78 @@ def test_mt5_connector_concurrency():
     assert len(connector.get_open_positions()) == 0
 
 
+def test_strategy_config_reset_from_instance():
+    """
+    Given a StrategyConfig instance with mutated fields,
+    when .reset_from(StrategyConfig(mock_mode=True)) is called,
+    then all fields match the fresh instance's values without touching private internals.
+    """
+    config = StrategyConfig(
+        symbol="GBPUSD",
+        timeframe="H1",
+        risk_per_trade_pct=2.5,
+        max_daily_drawdown_pct=5.0,
+        mt5_login=987654,
+        mt5_server="Darwinex-Live",
+        mock_mode=False,
+        fast_ema_period=9,
+        slow_ema_period=21,
+    )
+
+    fresh = StrategyConfig(mock_mode=True)
+    res = config.reset_from(fresh)
+
+    assert res is config
+    assert config.symbol == "EURUSD"
+    assert config.timeframe == "M15"
+    assert config.risk_per_trade_pct == 1.0
+    assert config.max_daily_drawdown_pct == 3.0
+    assert config.mt5_login == 0
+    assert config.mt5_server == "Darwinex-Demo"
+    assert config.mock_mode is True
+    assert config.fast_ema_period == 12
+    assert config.slow_ema_period == 26
+    assert config.model_dump() == fresh.model_dump()
+
+
+def test_strategy_config_reset_from_defaults_and_overrides():
+    """
+    Verifies reset_from() with kwargs overrides and empty arguments resets to default values.
+    """
+    config = StrategyConfig(symbol="USDJPY", mock_mode=False, mt5_login=123)
+    config.reset_from(symbol="BTCUSD", mock_mode=True)
+
+    assert config.symbol == "BTCUSD"
+    assert config.mock_mode is True
+    assert config.mt5_login == 0
+
+    # Calling reset_from() without arguments restores defaults
+    config.reset_from()
+    assert config.symbol == "EURUSD"
+    assert config.mock_mode is True
+
+
+def test_strategy_config_reset_from_idempotency_and_side_effects():
+    """
+    Given reset_from(), when called repeatedly in sequence,
+    then it is idempotent and side-effect free beyond the target instance.
+    """
+    source = StrategyConfig(symbol="AUDUSD", mock_mode=True, fast_ema_period=8)
+    target = StrategyConfig()
+
+    # First call
+    target.reset_from(source)
+    assert target.symbol == "AUDUSD"
+    assert target.fast_ema_period == 8
+
+    # Second call (idempotent)
+    target.reset_from(source)
+    assert target.symbol == "AUDUSD"
+    assert target.fast_ema_period == 8
+
+    # Verify mutating source afterwards does not affect target
+    source.symbol = "NZDUSD"
+    assert target.symbol == "AUDUSD"
+
+
+


### PR DESCRIPTION
## Mission Plan

### Context & Goal
Under parent story #37, this PR implements subtask #38 by introducing StrategyConfig.reset_from() in strategy_engine/config.py. This method provides a clean, reusable mechanism to reset a live singleton configuration instance to fresh defaults or custom overrides without reaching into private Pydantic v2 internals (__dict__ and __pydantic_fields_set__).

### Changes
1. strategy_engine/config.py: Added reset_from(self, other=None, **overrides) method.
2. api_gateway/tests/conftest.py: Replaced manual __dict__ and __pydantic_fields_set__ manipulation with global_config.reset_from(StrategyConfig(mock_mode=True)).
3. strategy_engine/tests/test_strategy.py: Added unit tests verifying reset_from with instance, kwargs, and idempotency.
4. CHANGELOG.md: Added entry under ## [Unreleased].

### Test Results
- Python Backend Tests: 22 passed across api_gateway/tests and strategy_engine/tests.
- Android Unit Tests: All snapshot debug unit tests passed.

Parent story: #37
Closes #38