### PR TITLE
Add explicit mt5_path teardown fixture for path-fallback and path-override connect tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Added unit test `test_connection_state_validation` in `strategy_engine/tests/test_strategy.py` verifying serialization and asserting `ValidationError` is raised for invalid status strings.
 
 ### Added
+- **Explicit MT5 Path Teardown Fixture for Connect Tests**:
+  - Added `preserve_mt5_path` fixture in `api_gateway/tests/conftest.py` that snapshots `global_config.mt5_path` and restores it in a teardown `finally` block.
+  - Updated `test_account_connect_path_fallback_preserves_config` and `test_account_connect_explicit_path_overrides_config` in `api_gateway/tests/test_api.py` to use `preserve_mt5_path` explicitly.
 - **StrategyConfig.reset_from Helper for Safe Fixture State Reset**:
   - Added `StrategyConfig.reset_from(other, **overrides)` in `strategy_engine/config.py` enabling bulk resets of live configuration singleton instances without manipulating private Pydantic internals (`__dict__`, `__pydantic_fields_set__`).
   - Refactored `api_gateway/tests/conftest.py` autouse isolation fixture to use `global_config.reset_from()`.

--- a/api_gateway/tests/conftest.py
+++ b/api_gateway/tests/conftest.py
@@ -23,3 +23,18 @@ def reset_shared_state():
     _reset()
     yield
     _reset()
+
+
+@pytest.fixture
+def preserve_mt5_path():
+    """
+    Explicit fixture that snapshots `global_config.mt5_path` before test execution
+    and restores the pre-test value after test completion, ensuring explicit test-local
+    teardown when tests mutate the MT5 terminal path.
+    """
+    original_path = global_config.mt5_path
+    try:
+        yield
+    finally:
+        global_config.mt5_path = original_path
+

--- a/api_gateway/tests/test_api.py
+++ b/api_gateway/tests/test_api.py
@@ -135,7 +135,7 @@ def test_account_connect_and_status_failure(monkeypatch):
     assert status_data["account_info"] is None
 
 
-def test_account_connect_path_fallback_preserves_config():
+def test_account_connect_path_fallback_preserves_config(preserve_mt5_path):
     from api_gateway.routes_strategy import global_config
 
     configured_path = "C:\\Configured\\Darwinex MetaTrader 5\\terminal64.exe"
@@ -169,7 +169,7 @@ def test_account_connect_path_fallback_preserves_config():
     assert global_config.mt5_path == configured_path
 
 
-def test_account_connect_explicit_path_overrides_config():
+def test_account_connect_explicit_path_overrides_config(preserve_mt5_path):
     from api_gateway.routes_strategy import global_config
 
     global_config.mt5_path = "C:\\Default\\Path\\terminal64.exe"


### PR DESCRIPTION
## Summary
This PR adds a dedicated `preserve_mt5_path` fixture in `api_gateway/tests/conftest.py` that snapshots `global_config.mt5_path` before test execution and restores it in a teardown `finally` block. The fixture is explicitly applied to `test_account_connect_path_fallback_preserves_config` and `test_account_connect_explicit_path_overrides_config` in `api_gateway/tests/test_api.py`.

## Changes
- **`api_gateway/tests/conftest.py`**: Added `preserve_mt5_path` fixture for explicit snapshot and restoration of `global_config.mt5_path`.
- **`api_gateway/tests/test_api.py`**: Injected `preserve_mt5_path` into `test_account_connect_path_fallback_preserves_config` and `test_account_connect_explicit_path_overrides_config`.
- **`CHANGELOG.md`**: Documented new fixture and test updates under `## [Unreleased]`.

## Verification & Test Results
- `python -m pytest api_gateway/tests/test_api.py -k path -p randomly`: Passed in random order.
- `python -m pytest api_gateway/tests strategy_engine/tests`: All 22 tests passed.
- `cd android; .\gradlew.bat testSnapshotDebugUnitTest --no-daemon; cd ..`: All unit tests passed.

Part of parent story #37
Closes #40